### PR TITLE
changed cmake to use a new build type for drd Tokutek/ft-engine#48

### DIFF
--- a/cmake_modules/TokuThirdParty.cmake
+++ b/cmake_modules/TokuThirdParty.cmake
@@ -43,7 +43,7 @@ if (APPLE)
 endif ()
 
 list(APPEND xz_configure_opts CC=${CMAKE_C_COMPILER})
-if (NOT CMAKE_BUILD_TYPE MATCHES Release)
+if (CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL drd)
   list(APPEND xz_configure_opts --enable-debug)
 endif ()
 


### PR DESCRIPTION
This lets us use CMAKE_BUILD_TYPE=drd instead of hijacking
RelWithDebInfo.

Also, make RelWithDebInfo synonymous with Release so we can build
MySQL/MariaDB that way.
