### PR TITLE
use cpu affinity to compute number of cpus and set background thread pool size

### DIFF
--- a/cmake_modules/TokuFeatureDetection.cmake
+++ b/cmake_modules/TokuFeatureDetection.cmake
@@ -43,6 +43,7 @@ check_include_files(sys/sysctl.h HAVE_SYS_SYSCTL_H)
 check_include_files(sys/syslimits.h HAVE_SYS_SYSLIMITS_H)
 check_include_files(sys/time.h HAVE_SYS_TIME_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
+check_include_files(sched.h HAVE_SCHED_H)
 
 include(CheckSymbolExists)
 
@@ -112,6 +113,7 @@ check_function_exists(pthread_yield_np HAVE_PTHREAD_YIELD_NP)
 ## check if we have pthread_getthreadid_np() (i.e. freebsd)
 check_function_exists(pthread_getthreadid_np HAVE_PTHREAD_GETTHREADID_NP)
 check_function_exists(sched_getcpu HAVE_SCHED_GETCPU)
+check_function_exists(sched_getaffinity HAVE_SCHED_GETAFFINITY)
 
 include(CheckCSourceCompiles)
 

--- a/ft/cachetable/cachetable.cc
+++ b/ft/cachetable/cachetable.cc
@@ -307,7 +307,7 @@ int toku_cachetable_create(CACHETABLE *ct_result, long size_limit, LSN UU(initia
     ct->list.init();
     ct->cf_list.init();
 
-    int num_processors = toku_os_get_number_active_processors();
+    int num_processors = toku_os_get_number_cpus();
     int checkpointing_nworkers = (num_processors/4) ? num_processors/4 : 1;
     r = toku_kibbutz_create(num_processors, &ct->client_kibbutz);
     if (r != 0) {

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -149,7 +149,7 @@ void toku_serialize_set_parallel(bool in_parallel) {
 }
 
 void toku_ft_serialize_layer_init(void) {
-    num_cores = toku_os_get_number_active_processors();
+    num_cores = toku_os_get_number_cpus();
     int r = toku_thread_pool_create(&ft_pool, num_cores);
     lazy_assert_zero(r);
     block_allocator::maybe_initialize_trace();

--- a/portability/tests/test-active-cpus.cc
+++ b/portability/tests/test-active-cpus.cc
@@ -101,7 +101,7 @@ int main(void) {
     assert(r == 0);
 
     int max_cpus = sysconf(_SC_NPROCESSORS_ONLN);
-    assert(toku_os_get_number_active_processors() == max_cpus);
+    assert(toku_os_get_number_cpus() == max_cpus);
 
     // change the TOKU_NCPUS env variable and verify that the correct number is computed
     for (int ncpus = 1; ncpus <= max_cpus; ncpus++) {
@@ -110,7 +110,7 @@ int main(void) {
         r = setenv("TOKU_NCPUS", ncpus_str, 1);
         assert(r == 0);
 
-        assert(toku_os_get_number_active_processors() == ncpus);
+        assert(toku_os_get_number_cpus() == ncpus);
     }
 
     return 0;

--- a/portability/toku_config.h.in
+++ b/portability/toku_config.h.in
@@ -41,6 +41,7 @@
 #cmakedefine HAVE_SYS_SYSLIMITS_H 1
 #cmakedefine HAVE_SYS_TIME_H 1
 #cmakedefine HAVE_UNISTD_H 1
+#cmakedefine HAVE_SCHED_H 1
 
 #cmakedefine HAVE_M_MMAP_THRESHOLD 1
 #cmakedefine HAVE_CLOCK_REALTIME 1
@@ -63,6 +64,7 @@
 #cmakedefine PTHREAD_YIELD_RETURNS_VOID 1
 
 #cmakedefine HAVE_SCHED_GETCPU 1
+#cmakedefine HAVE_SCHED_GETAFFINITY 1
 
 #cmakedefine HAVE_GNU_TLS 1
 

--- a/portability/toku_os.h
+++ b/portability/toku_os.h
@@ -103,11 +103,8 @@ int toku_os_getpid(void)   __attribute__((__visibility__("default")));
 // Returns: the current thread id
 int toku_os_gettid(void)  __attribute__((__visibility__("default")));
 
-// Returns: the number of processors in the system
-int toku_os_get_number_processors(void);
-
-// Returns: the number of active processors in the system
-int toku_os_get_number_active_processors(void);
+// Returns: the number of cpus in the system
+int toku_os_get_number_cpus(void);
 
 // Returns: the system page size (in bytes)
 int toku_os_get_pagesize(void);

--- a/src/tests/threaded_stress_test_helpers.h
+++ b/src/tests/threaded_stress_test_helpers.h
@@ -1168,7 +1168,7 @@ static void scan_op_worker(void *arg) {
 }
 
 static int UU() scan_op_no_check_parallel(DB_TXN *txn, ARG arg, void* operation_extra, void *UU(stats_extra)) {
-    const int num_cores = toku_os_get_number_processors();
+    const int num_cores = toku_os_get_number_cpus();
     const int num_workers = arg->cli->num_DBs < num_cores ? arg->cli->num_DBs : num_cores;
     KIBBUTZ kibbutz = NULL;
     int r = toku_kibbutz_create(num_workers, &kibbutz);
@@ -2124,7 +2124,7 @@ static void fill_table_worker(void *arg) {
 }
 
 static int fill_tables_default(DB_ENV *env, DB **dbs, struct cli_args *args, bool fill_with_zeroes) {
-    const int num_cores = toku_os_get_number_processors();
+    const int num_cores = toku_os_get_number_cpus();
     // Use at most cores / 2 worker threads, since we want some other cores to
     // be used for internal engine work (ie: flushes, loader threads, etc).
     const int max_num_workers = (num_cores + 1) / 2;

--- a/tools/ftverify.cc
+++ b/tools/ftverify.cc
@@ -478,7 +478,7 @@ main(int argc, char const * const argv[])
     }
 
     // body of toku_ft_serialize_init();
-    num_cores = toku_os_get_number_active_processors();
+    num_cores = toku_os_get_number_cpus();
     r = toku_thread_pool_create(&ft_pool, num_cores); lazy_assert_zero(r);
     assert_zero(r);
 


### PR DESCRIPTION
we currently use sysconf(_SC_NPROCESSORS_CONF) to compute the number of cpus that this process can run on.  this number is used to size background thread pools.  we should use the cpu affiniity info for this process instead.  this will allow the size of the thread pools to be set based on the number of threads that the process is allowed to run on.  this feature allows easy multi-tenant deployments.