### PR TITLE
FT-678 : add thread pool size controls for CLIENT, CACHETABLE or CHECKPOINT

### DIFF
--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -415,6 +415,9 @@ static void print_db_env_struct (void) {
                              "uint64_t (*get_loader_memory_size)(DB_ENV *env)",
                              "void (*set_killed_callback)(DB_ENV *env, uint64_t default_killed_time_msec, uint64_t (*get_killed_time_callback)(uint64_t default_killed_time_msec), int (*killed_callback)(void))",
                              "void (*do_backtrace)                        (DB_ENV *env)",
+                             "int (*set_client_pool_threads)(DB_ENV *, uint32_t)",
+                             "int (*set_cachetable_pool_threads)(DB_ENV *, uint32_t)",
+                             "int (*set_checkpoint_pool_threads)(DB_ENV *, uint32_t)",
                              NULL};
 
         sort_and_dump_fields("db_env", true, extra);

--- a/ft/cachetable/cachetable.cc
+++ b/ft/cachetable/cachetable.cc
@@ -206,7 +206,11 @@ uint32_t toku_get_cleaner_iterations_unlocked (CACHETABLE ct) {
 // reserve 25% as "unreservable".  The loader cannot have it.
 #define unreservable_memory(size) ((size)/4)
 
-int toku_cachetable_create(CACHETABLE *ct_result, long size_limit, LSN UU(initial_lsn), TOKULOGGER logger) {
+int toku_cachetable_create_ex(CACHETABLE *ct_result, long size_limit,
+                           unsigned long client_pool_threads,
+                           unsigned long cachetable_pool_threads,
+                           unsigned long checkpoint_pool_threads,
+                           LSN UU(initial_lsn), TOKULOGGER logger) {
     int result = 0;
     int r;
 
@@ -220,17 +224,20 @@ int toku_cachetable_create(CACHETABLE *ct_result, long size_limit, LSN UU(initia
 
     int num_processors = toku_os_get_number_active_processors();
     int checkpointing_nworkers = (num_processors/4) ? num_processors/4 : 1;
-    r = toku_kibbutz_create(num_processors, &ct->client_kibbutz);
+    r = toku_kibbutz_create(client_pool_threads ? client_pool_threads : num_processors,
+                            &ct->client_kibbutz);
     if (r != 0) {
         result = r;
         goto cleanup;
     }
-    r = toku_kibbutz_create(2*num_processors, &ct->ct_kibbutz);
+    r = toku_kibbutz_create(cachetable_pool_threads ? cachetable_pool_threads : 2*num_processors,
+                            &ct->ct_kibbutz);
     if (r != 0) {
         result = r;
         goto cleanup;
     }
-    r = toku_kibbutz_create(checkpointing_nworkers, &ct->checkpointing_kibbutz);
+    r = toku_kibbutz_create(checkpoint_pool_threads ? checkpoint_pool_threads : checkpointing_nworkers,
+                            &ct->checkpointing_kibbutz);
     if (r != 0) {
         result = r;
         goto cleanup;

--- a/ft/cachetable/cachetable.h
+++ b/ft/cachetable/cachetable.h
@@ -108,7 +108,14 @@ uint32_t toku_get_cleaner_iterations_unlocked (CACHETABLE ct);
 // create and initialize a cache table
 // size_limit is the upper limit on the size of the size of the values in the table
 // pass 0 if you want the default
-int toku_cachetable_create(CACHETABLE *result, long size_limit, LSN initial_lsn, struct tokulogger *logger);
+int toku_cachetable_create_ex(CACHETABLE *result, long size_limit,
+                           unsigned long client_pool_threads,
+                           unsigned long cachetable_pool_threads,
+                           unsigned long checkpoint_pool_threads,
+                           LSN initial_lsn, struct tokulogger *logger);
+
+#define toku_cachetable_create(r, s, l, o) \
+    toku_cachetable_create_ex(r, s, 0, 0, 0, l, 0);
 
 // Create a new cachetable.
 // Effects: a new cachetable is created and initialized.

--- a/src/ydb-internal.h
+++ b/src/ydb-internal.h
@@ -98,6 +98,9 @@ struct __toku_db_env_internal {
     generate_row_for_del_func generate_row_for_del;
 
     unsigned long cachetable_size;
+    unsigned long client_pool_threads;
+    unsigned long cachetable_pool_threads;
+    unsigned long checkpoint_pool_threads;
     CACHETABLE cachetable;
     TOKULOGGER logger;
     toku::locktree_manager ltm;

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -918,7 +918,11 @@ env_open(DB_ENV * env, const char *home, uint32_t flags, int mode) {
 
     if (env->i->cachetable==NULL) {
         // If we ran recovery then the cachetable should be set here.
-        r = toku_cachetable_create(&env->i->cachetable, env->i->cachetable_size, ZERO_LSN, env->i->logger);
+        r = toku_cachetable_create_ex(&env->i->cachetable, env->i->cachetable_size,
+                                   env->i->client_pool_threads,
+                                   env->i->cachetable_pool_threads,
+                                   env->i->checkpoint_pool_threads,
+                                   ZERO_LSN, env->i->logger);
         if (r != 0) {
             r = toku_ydb_do_error(env, r, "Cant create a cachetable\n");
             goto cleanup;
@@ -1206,6 +1210,27 @@ env_set_cachesize(DB_ENV * env, uint32_t gbytes, uint32_t bytes, int ncache) {
         return EINVAL;
     }
     env->i->cachetable_size = cs;
+    return 0;
+}
+
+static int 
+env_set_client_pool_threads(DB_ENV * env, uint32_t threads) {
+    HANDLE_PANICKED_ENV(env);
+    env->i->client_pool_threads = threads;
+    return 0;
+}
+
+static int 
+env_set_cachetable_pool_threads(DB_ENV * env, uint32_t threads) {
+    HANDLE_PANICKED_ENV(env);
+    env->i->cachetable_pool_threads = threads;
+    return 0;
+}
+
+static int 
+env_set_checkpoint_pool_threads(DB_ENV * env, uint32_t threads) {
+    HANDLE_PANICKED_ENV(env);
+    env->i->checkpoint_pool_threads = threads;
     return 0;
 }
 
@@ -2555,6 +2580,9 @@ toku_env_create(DB_ENV ** envp, uint32_t flags) {
     USENV(cleaner_set_iterations);
     USENV(cleaner_get_iterations);
     USENV(set_cachesize);
+    USENV(set_client_pool_threads);
+    USENV(set_cachetable_pool_threads);
+    USENV(set_checkpoint_pool_threads);
 #if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 3
     USENV(get_cachesize);
 #endif


### PR DESCRIPTION
Must be specified at ENV.open, not dynamic.