### PR TITLE
DB-818 fix reserved filenum overflow

### DIFF
--- a/ft/tests/cachetable-reserve-filenum.cc
+++ b/ft/tests/cachetable-reserve-filenum.cc
@@ -1,0 +1,176 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*
+COPYING CONDITIONS NOTICE:
+
+  This program is free software; you can redistribute it and/or modify
+  it under the terms of version 2 of the GNU General Public License as
+  published by the Free Software Foundation, and provided that the
+  following conditions are met:
+
+      * Redistributions of source code must retain this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below).
+
+      * Redistributions in binary form must reproduce this COPYING
+        CONDITIONS NOTICE, the COPYRIGHT NOTICE (below), the
+        DISCLAIMER (below), the UNIVERSITY PATENT NOTICE (below), the
+        PATENT MARKING NOTICE (below), and the PATENT RIGHTS
+        GRANT (below) in the documentation and/or other materials
+        provided with the distribution.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+  02110-1301, USA.
+
+COPYRIGHT NOTICE:
+
+  TokuFT, Tokutek Fractal Tree Indexing Library.
+  Copyright (C) 2007-2013 Tokutek, Inc.
+
+DISCLAIMER:
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+  General Public License for more details.
+
+UNIVERSITY PATENT NOTICE:
+
+  The technology is licensed by the Massachusetts Institute of
+  Technology, Rutgers State University of New Jersey, and the Research
+  Foundation of State University of New York at Stony Brook under
+  United States of America Serial No. 11/760379 and to the patents
+  and/or patent applications resulting from it.
+
+PATENT MARKING NOTICE:
+
+  This software is covered by US Patent No. 8,185,551.
+  This software is covered by US Patent No. 8,489,638.
+
+PATENT RIGHTS GRANT:
+
+  "THIS IMPLEMENTATION" means the copyrightable works distributed by
+  Tokutek as part of the Fractal Tree project.
+
+  "PATENT CLAIMS" means the claims of patents that are owned or
+  licensable by Tokutek, both currently or in the future; and that in
+  the absence of this license would be infringed by THIS
+  IMPLEMENTATION or by using or running THIS IMPLEMENTATION.
+
+  "PATENT CHALLENGE" shall mean a challenge to the validity,
+  patentability, enforceability and/or non-infringement of any of the
+  PATENT CLAIMS or otherwise opposing any of the PATENT CLAIMS.
+
+  Tokutek hereby grants to you, for the term and geographical scope of
+  the PATENT CLAIMS, a non-exclusive, no-charge, royalty-free,
+  irrevocable (except as stated in this section) patent license to
+  make, have made, use, offer to sell, sell, import, transfer, and
+  otherwise run, modify, and propagate the contents of THIS
+  IMPLEMENTATION, where such license applies only to the PATENT
+  CLAIMS.  This grant does not include claims that would be infringed
+  only as a consequence of further modifications of THIS
+  IMPLEMENTATION.  If you or your agent or licensee institute or order
+  or agree to the institution of patent litigation against any entity
+  (including a cross-claim or counterclaim in a lawsuit) alleging that
+  THIS IMPLEMENTATION constitutes direct or contributory patent
+  infringement, or inducement of patent infringement, then any rights
+  granted to you under this License shall terminate as of the date
+  such litigation is filed.  If you or your agent or exclusive
+  licensee institute or order or agree to the institution of a PATENT
+  CHALLENGE, then Tokutek may terminate any rights granted to you
+  under this License.
+*/
+
+#ident "Copyright (c) 2007-2013 Tokutek Inc.  All rights reserved."
+
+#include "test.h"
+#include "cachetable/cachetable-internal.h"
+#include "cachetable-test.h"
+
+struct reserve_filenum_test {
+  // Tests
+  void test_reserve_filenum();
+  void test_reserve_filenum_active();
+};
+
+
+//------------------------------------------------------------------------------
+// test_reserve_filenum() -
+//
+// Description:
+//
+void reserve_filenum_test::test_reserve_filenum() {
+    cachefile_list cfl;
+    cfl.init();
+
+    // set m_next_filenum_to_use.fileid
+    cfl.m_next_filenum_to_use.fileid = (UINT32_MAX -2);
+
+    FILENUM fn1 = cfl.reserve_filenum();
+    assert(fn1.fileid == (UINT32_MAX - 2));
+
+    FILENUM fn2 = cfl.reserve_filenum();
+    assert(fn2.fileid == (UINT32_MAX - 1));
+
+    // skip the reversed value UINT32_MAX and wrap around
+    FILENUM fn3 = cfl.reserve_filenum();
+    assert(fn3.fileid == 0U);
+
+    FILENUM fn4 = cfl.reserve_filenum();
+    assert(fn4.fileid == 1U);
+
+    cfl.destroy();
+}
+
+void reserve_filenum_test::test_reserve_filenum_active() {
+    cachefile_list cfl;
+    cfl.init();
+
+    // start the filenum space to UINT32_MAX - 1
+    cfl.m_next_filenum_to_use.fileid = (UINT32_MAX -1);
+
+    // reserve filenum UINT32_MAX-1
+    FILENUM fn1 = cfl.reserve_filenum();
+    assert(fn1.fileid == (UINT32_MAX - 1));
+    cachefile cf1 = {};
+    cf1.filenum = fn1;
+    cf1.fileid = {0, 1};
+    cfl.add_cf_unlocked(&cf1);
+
+    // reset next filenum so that we test skipping UINT32_MAX
+    cfl.m_next_filenum_to_use.fileid = (UINT32_MAX -1);
+
+    // reserve filenum 0
+    FILENUM fn2 = cfl.reserve_filenum();
+    assert(fn2.fileid == 0);
+
+    cachefile cf2 = {};
+    cf2.filenum = fn2;
+    cf2.fileid = {0, 2};
+    cfl.add_cf_unlocked(&cf2);
+
+    cfl.destroy();
+}
+
+//------------------------------------------------------------------------------
+// test_main() -
+//
+// Description:
+//
+int
+test_main(int argc, const char *argv[]) {
+    int r = 0;
+    default_parse_args(argc, argv);
+    reserve_filenum_test fn_test;
+
+    // Run the tests.
+    fn_test.test_reserve_filenum();
+    fn_test.test_reserve_filenum_active();
+
+    return r;
+}


### PR DESCRIPTION
[summary]
We have got an error on our production:
toku_cachetable_openfd_with_filenum: Assertion 'filenum.fileid != FILENUM_NONE.fileid' failed

From the gdb statck, I got:
(gdb) p reserved_filenum
 = {fileid = 4294967295}

Deep in the 'reserve_filenum' codes, found that:
a) this function just return the m_next_filenum_to_use, not the un-used filenum.
b) m_next_filenum_to_use is UINT32， if we have many ft opens, it maybe overflow

From the crash instance data dir, we got one database has 180,000 tokudb files, so it's easy to trigger the assert.

Casey Brown has reported this issue here:
https://tokutek.atlassian.net/browse/DB-818

[testcase]
ft/tests/cachetable-reserve-filenum.cc

Reviewed By: Rich