### PR TITLE
FT-691 (CMake fails on case-insensitive FS, such as Mac OS X)

### DIFF
--- a/cmake_modules/TokuBuildTagDatabases.cmake
+++ b/cmake_modules/TokuBuildTagDatabases.cmake
@@ -33,6 +33,21 @@ list(APPEND all_hdrs
   ${CMAKE_CURRENT_BINARY_DIR}/ft/log_header.h
   )
 
+option(USE_ETAGS "Build the etags database." ON)
+if (USE_ETAGS)
+  find_program(ETAGS "etags")
+  if (NOT ETAGS MATCHES NOTFOUND)
+    add_custom_command(
+      OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/TAGS"
+      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/etags-stamp"
+      COMMAND ${ETAGS} -o TAGS ${all_srcs} ${all_hdrs}
+      COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/etags-stamp"
+      DEPENDS ${all_srcs} ${all_hdrs} install_tdb_h generate_config_h generate_log_code
+      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+    add_custom_target(build_etags ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/TAGS" etags-stamp)
+  endif ()
+endif ()
+
 option(USE_CTAGS "Build the ctags database." ON)
 if (USE_CTAGS AND
     # Macs by default are not case-sensitive, so tags and TAGS clobber each other.  Do etags and not ctags in that case, because Emacs is superior. :P
@@ -47,21 +62,6 @@ if (USE_CTAGS AND
       DEPENDS ${all_srcs} ${all_hdrs} install_tdb_h generate_config_h generate_log_code
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
     add_custom_target(build_ctags ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/tags" ctags-stamp)
-  endif ()
-endif ()
-
-option(USE_ETAGS "Build the etags database." ON)
-if (USE_ETAGS)
-  find_program(ETAGS "etags")
-  if (NOT ETAGS MATCHES NOTFOUND)
-    add_custom_command(
-      OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/TAGS"
-      OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/etags-stamp"
-      COMMAND ${ETAGS} -o TAGS ${all_srcs} ${all_hdrs}
-      COMMAND touch "${CMAKE_CURRENT_BINARY_DIR}/etags-stamp"
-      DEPENDS ${all_srcs} ${all_hdrs} install_tdb_h generate_config_h generate_log_code
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
-    add_custom_target(build_etags ALL DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/TAGS" etags-stamp)
   endif ()
 endif ()
 


### PR DESCRIPTION
Swap option(USE_ETAGS ... ) and option(USE_CTAGS ... ) in
cmake_modules/TokuBuildTagDatabases.cmake, so that if USE_ETAGS is
processed first and USE_CTAGS then is properly disabled on Mac OS X.