### PR TITLE
FT-692 (DB_LSN warning: empty struct has size 0 in C, size 1 in C++)

### DIFF
--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -430,7 +430,9 @@ static void print_db_key_range_struct (void) {
 
 static void print_db_lsn_struct (void) {
     field_counter=0;
-    sort_and_dump_fields("db_lsn", false, NULL);
+    /* A dummy field to make sizeof(DB_LSN) equal in C and C++ */
+    const char *extra[] = { "char dummy", NULL };
+    sort_and_dump_fields("db_lsn", false, extra);
 }
 
 static void print_dbt_struct (void) {


### PR DESCRIPTION
Add a dummy field to DB_LSN struct so its sizeof becomes the same in
both C and C++.