### PR TITLE
document the problems with the helgrind annotations of unsafe fetch and set

### DIFF
--- a/ft/cachetable/cachetable.cc
+++ b/ft/cachetable/cachetable.cc
@@ -2425,7 +2425,7 @@ toku_cachetable_minicron_shutdown(CACHETABLE ct) {
 
 void toku_cachetable_prepare_close(CACHETABLE ct UU()) {
     extern bool toku_serialize_in_parallel;
-    toku_drd_unsafe_set(&toku_serialize_in_parallel, true);
+    toku_unsafe_set(&toku_serialize_in_parallel, true);
 }
 
 /* Requires that it all be flushed. */

--- a/ft/ft-flusher.cc
+++ b/ft/ft-flusher.cc
@@ -497,7 +497,7 @@ handle_split_of_child(
     // We never set the rightmost blocknum to be the root.
     // Instead, we wait for the root to split and let promotion initialize the rightmost
     // blocknum to be the first non-root leaf node on the right extreme to recieve an insert.
-    BLOCKNUM rightmost_blocknum = toku_drd_unsafe_fetch(&ft->rightmost_blocknum);
+    BLOCKNUM rightmost_blocknum = toku_unsafe_fetch(&ft->rightmost_blocknum);
     invariant(ft->h->root_blocknum.b != rightmost_blocknum.b);
     if (childa->blocknum.b == rightmost_blocknum.b) {
         // The rightmost leaf (a) split into (a) and (b). We want (b) to swap pair values
@@ -1326,7 +1326,7 @@ ft_merge_child(
             node->pivotkeys.delete_at(childnuma);
 
             // Handle a merge of the rightmost leaf node.
-            BLOCKNUM rightmost_blocknum = toku_drd_unsafe_fetch(&ft->rightmost_blocknum); 
+            BLOCKNUM rightmost_blocknum = toku_unsafe_fetch(&ft->rightmost_blocknum); 
             if (did_merge && childb->blocknum.b == rightmost_blocknum.b) {
                 invariant(childb->blocknum.b != ft->h->root_blocknum.b);
                 toku_ftnode_swap_pair_values(childa, childb);

--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -988,7 +988,7 @@ exit:
 // We need a function to have something a drd suppression can reference
 // see src/tests/drd.suppressions (unsafe_touch_clock)
 static void unsafe_touch_clock(FTNODE node, int i) {
-    toku_drd_unsafe_set(&node->bp[i].clock_count, static_cast<unsigned char>(1));
+    toku_unsafe_set(&node->bp[i].clock_count, static_cast<unsigned char>(1));
 }
 
 // Callback that states if a partial fetch of the node is necessary
@@ -1408,13 +1408,13 @@ static void inject_message_in_locked_node(
     paranoid_invariant(msg_with_msn.msn().msn == node->max_msn_applied_to_node_on_disk.msn);
 
     if (node->blocknum.b == ft->rightmost_blocknum.b) {
-        if (toku_drd_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
+        if (toku_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
             // we promoted to the rightmost leaf node and the seqinsert score has not yet saturated.
             toku_sync_fetch_and_add(&ft->seqinsert_score, 1);
         }
-    } else if (toku_drd_unsafe_fetch(&ft->seqinsert_score) != 0) {
+    } else if (toku_unsafe_fetch(&ft->seqinsert_score) != 0) {
         // we promoted to something other than the rightmost leaf node and the score should reset
-        toku_drd_unsafe_set(&ft->seqinsert_score, static_cast<uint32_t>(0));
+        toku_unsafe_set(&ft->seqinsert_score, static_cast<uint32_t>(0));
     }
 
     // if we call toku_ft_flush_some_child, then that function unpins the root
@@ -1576,16 +1576,16 @@ static inline bool should_inject_in_node(seqinsert_loc loc, int height, int dept
 static void ft_verify_or_set_rightmost_blocknum(FT ft, BLOCKNUM b)
 // Given: 'b', the _definitive_ and constant rightmost blocknum of 'ft'
 {
-    if (toku_drd_unsafe_fetch(&ft->rightmost_blocknum.b) == RESERVED_BLOCKNUM_NULL) {
+    if (toku_unsafe_fetch(&ft->rightmost_blocknum.b) == RESERVED_BLOCKNUM_NULL) {
         toku_ft_lock(ft);
         if (ft->rightmost_blocknum.b == RESERVED_BLOCKNUM_NULL) {
-            toku_drd_unsafe_set(&ft->rightmost_blocknum, b);
+            toku_unsafe_set(&ft->rightmost_blocknum, b);
         }
         toku_ft_unlock(ft);
     }
     // The rightmost blocknum only transitions from RESERVED_BLOCKNUM_NULL to non-null.
     // If it's already set, verify that the stored value is consistent with 'b'
-    invariant(toku_drd_unsafe_fetch(&ft->rightmost_blocknum.b) == b.b);
+    invariant(toku_unsafe_fetch(&ft->rightmost_blocknum.b) == b.b);
 }
 
 bool toku_bnc_should_promote(FT ft, NONLEAF_CHILDINFO bnc) {
@@ -2069,7 +2069,7 @@ static int ft_maybe_insert_into_rightmost_leaf(FT ft, DBT *key, DBT *val, XIDS m
 
     // Don't do the optimization if our heurstic suggests that
     // insertion pattern is not sequential.
-    if (toku_drd_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
+    if (toku_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
         goto cleanup;
     }
 

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -92,7 +92,7 @@ struct toku_thread_pool *get_ft_pool(void) {
 }
 
 void toku_serialize_set_parallel(bool in_parallel) {
-    toku_drd_unsafe_set(&toku_serialize_in_parallel, in_parallel);
+    toku_unsafe_set(&toku_serialize_in_parallel, in_parallel);
 }
 
 void toku_ft_serialize_layer_init(void) {
@@ -799,7 +799,7 @@ toku_serialize_ftnode_to (int fd, BLOCKNUM blocknum, FTNODE node, FTNODE_DISK_DA
         ft->h->basementnodesize,
         ft->h->compression_method,
         do_rebalancing,
-        toku_drd_unsafe_fetch(&toku_serialize_in_parallel),
+        toku_unsafe_fetch(&toku_serialize_in_parallel),
         &n_to_write,
         &n_uncompressed_bytes,
         &compressed_buf

--- a/ft/txn/rollback.cc
+++ b/ft/txn/rollback.cc
@@ -92,7 +92,7 @@ static inline PAIR_ATTR make_rollback_pair_attr(long size) {
 PAIR_ATTR
 rollback_memory_size(ROLLBACK_LOG_NODE log) {
     size_t size = sizeof(*log);
-    if (&log->rollentry_arena) {
+    if (1) { // if (&log->rollentry_arena) {
         size += log->rollentry_arena.total_footprint();
     }
     return make_rollback_pair_attr(size);

--- a/ft/txn/txn.cc
+++ b/ft/txn/txn.cc
@@ -178,7 +178,7 @@ toku_txn_begin_with_xid (
         // this call will set txn->xids
         txn_create_xids(txn, parent);
     }
-    toku_drd_unsafe_set(txnp, txn);
+    toku_unsafe_set(txnp, txn);
 exit:
     return r;
 }

--- a/ft/txn/txn_manager.cc
+++ b/ft/txn/txn_manager.cc
@@ -287,7 +287,7 @@ toku_txn_manager_get_oldest_living_xid(TXN_MANAGER txn_manager) {
 }
 
 TXNID toku_txn_manager_get_oldest_referenced_xid_estimate(TXN_MANAGER txn_manager) {
-    return toku_drd_unsafe_fetch(&txn_manager->last_calculated_oldest_referenced_xid);
+    return toku_unsafe_fetch(&txn_manager->last_calculated_oldest_referenced_xid);
 }
 
 int live_root_txn_list_iter(const TOKUTXN &live_xid, const uint32_t UU(index), TXNID **const referenced_xids);
@@ -347,7 +347,7 @@ static void set_oldest_referenced_xid(TXN_MANAGER txn_manager) {
         oldest_referenced_xid = txn_manager->last_xid;
     }
     invariant(oldest_referenced_xid != TXNID_MAX);
-    toku_drd_unsafe_set(&txn_manager->last_calculated_oldest_referenced_xid, oldest_referenced_xid);
+    toku_unsafe_set(&txn_manager->last_calculated_oldest_referenced_xid, oldest_referenced_xid);
 }
 
 //Heaviside function to find a TOKUTXN by TOKUTXN (used to find the index)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -174,7 +174,6 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
 
   declare_custom_tests(test_groupcommit_count.tdb)
   add_ydb_test(test_groupcommit_count.tdb -n 1)
-  add_ydb_helgrind_test(test_groupcommit_count.tdb -n 2)
   add_ydb_drd_test(test_groupcommit_count.tdb -n 2)
 
   add_ydb_drd_test(test_4015.tdb)


### PR DESCRIPTION
document the problems with the helgrind annotations of unsafe fetch and set.  see http://prohaska7.blogspot.com/2015/08/races-in-tokuft-race-detector.html

    Copyright (c) 2015, Rich Prohaska
    All rights reserved.

    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribu

    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS