### PR TITLE
FT-694 (-DBUILD_TESTING=ON fails build on Mac OS X)

### DIFF
--- a/util/scoped_malloc.cc
+++ b/util/scoped_malloc.cc
@@ -60,6 +60,8 @@ namespace toku {
 
 void toku_scoped_malloc_init(void) {}
 void toku_scoped_malloc_destroy(void) {}
+void toku_scoped_malloc_destroy_set(void) {}
+void toku_scoped_malloc_destroy_key(void) {}
 
 #else // __APPLE__
 


### PR DESCRIPTION
Add missing stub functions toku_scoped_malloc_destroy_set and
toku_scoped_malloc_destroy_key for Mac OS X.