### PR TITLE
Introduce TOKU_FILE struct as a wrapper for FILE

### DIFF
--- a/ft/loader/loader-internal.h
+++ b/ft/loader/loader-internal.h
@@ -66,7 +66,7 @@ struct file_info {
     bool is_open;
     bool is_extant; // if true, the file must be unlinked.
     char *fname;
-    FILE *file;
+    TOKU_FILE *file;
     uint64_t n_rows; // how many rows were written into that file
     size_t buffer_size;
     void *buffer;
@@ -82,7 +82,7 @@ typedef struct fidx { int idx; } FIDX;
 static const FIDX FIDX_NULL __attribute__((__unused__)) = {-1};
 static int fidx_is_null (const FIDX f) __attribute__((__unused__));
 static int fidx_is_null (const FIDX f) { return f.idx==-1; }
-FILE *toku_bl_fidx2file (FTLOADER bl, FIDX i);
+TOKU_FILE *toku_bl_fidx2file (FTLOADER bl, FIDX i);
 
 int ft_loader_open_temp_file (FTLOADER bl, FIDX*file_idx);
 
@@ -103,8 +103,9 @@ int init_rowset (struct rowset *rows, uint64_t memory_budget);
 void destroy_rowset (struct rowset *rows);
 int add_row (struct rowset *rows, DBT *key, DBT *val);
 
-int loader_write_row(DBT *key, DBT *val, FIDX data, FILE*, uint64_t *dataoff, struct wbuf *wb, FTLOADER bl);
-int loader_read_row (FILE *f, DBT *key, DBT *val);
+int loader_write_row(DBT *key, DBT *val, FIDX data, TOKU_FILE*,
+                     uint64_t *dataoff, struct wbuf *wb, FTLOADER bl);
+int loader_read_row (TOKU_FILE *f, DBT *key, DBT *val);
 
 struct merge_fileset {
     bool have_sorted_output;  // Is there an previous key?
@@ -197,7 +198,7 @@ struct ft_loader_s {
     bool allow_puts;
     uint64_t   reserved_memory; // how much memory are we allowed to use?
 
-    /* To make it easier to recover from errors, we don't use FILE*, instead we use an index into the file_infos. */
+    /* To make it easier to recover from errors, we don't use TOKU_FILE*, instead we use an index into the file_infos. */
     struct file_infos file_infos;
 
 #define PROGRESS_MAX (1<<16)

--- a/portability/toku_instrumentation.h
+++ b/portability/toku_instrumentation.h
@@ -1,0 +1,47 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+  This file is part of PerconaFT.
+
+
+  Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+  PerconaFT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License, version 2,
+  as published by the Free Software Foundation.
+
+  PerconaFT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+
+  ----------------------------------------
+
+  PerconaFT is free software: you can redistribute it and/or modify
+  it under the terms of the GNU Affero General Public License, version 3,
+  as published by the Free Software Foundation.
+
+  PerconaFT is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU Affero General Public License for more details.
+
+  You should have received a copy of the GNU Affero General Public License
+  along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+  ======= */
+
+#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+
+#pragma once
+
+#include <stdio.h> // FILE
+
+struct TOKU_FILE
+{
+    FILE *file;
+    explicit TOKU_FILE(FILE* _file) : file(_file) { }
+};

--- a/portability/toku_portability.h
+++ b/portability/toku_portability.h
@@ -209,6 +209,8 @@ extern void *realloc(void*, size_t)            __THROW __attribute__((__deprecat
 };
 #endif
 
+#include "portability/toku_instrumentation.h"
+
 void *os_malloc(size_t) __attribute__((__visibility__("default")));
 // Effect: See man malloc(2)
 
@@ -240,12 +242,12 @@ ssize_t toku_os_pwrite (int fd, const void *buf, size_t len, toku_off_t off) __a
 int toku_os_write (int fd, const void *buf, size_t len) __attribute__((__visibility__("default")));
 
 // wrappers around file system calls
-FILE * toku_os_fdopen(int fildes, const char *mode);    
-FILE * toku_os_fopen(const char *filename, const char *mode);
+TOKU_FILE * toku_os_fdopen(int fildes, const char *mode);
+TOKU_FILE * toku_os_fopen(const char *filename, const char *mode);
 int toku_os_open(const char *path, int oflag, int mode);
 int toku_os_open_direct(const char *path, int oflag, int mode);
 int toku_os_close(int fd);
-int toku_os_fclose(FILE * stream);
+int toku_os_fclose(TOKU_FILE * stream);
 ssize_t toku_os_read(int fd, void *buf, size_t count);
 ssize_t toku_os_pread(int fd, void *buf, size_t count, off_t offset);
 void toku_os_recursive_delete(const char *path);


### PR DESCRIPTION
This is a prerequisite for adding performance schema and possibly
other kinds of instrumentation.

Create a struct TOKU_FILE that at the moment contains only a FILE *
field. Update functions to pass TOKU_FILE instead of FILE around.

If desired, it is possible to convert TOKU_FILE to a C++ class and
make its FILE field private in the future.

A new header file is created for this struct, toku_instrumentation.h.
This file is going to be used in the later instrumentation-introducing
commits.

The branch contains FT-694 fix merged as a prerequisite. Tested by verifying that ctest does not introduce any regressions against FT-694 branch (but see FT-695)
