### PR TITLE
added profiling option to allow profiling/debug. Jira ticket BLD-300

### DIFF
--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -117,7 +117,6 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
     )
 endif ()
 
-## 
 option (PROFILING "Allow profiling and debug" OFF)
 if (PROFILING)
   set_cflags_if_supported(

--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -117,6 +117,14 @@ if (NOT CMAKE_CXX_COMPILER_ID MATCHES Clang)
     )
 endif ()
 
+## 
+option (PROFILING "Allow profiling and debug" OFF)
+if (PROFILING)
+  set_cflags_if_supported(
+    -fno-omit-frame-pointer
+  )
+endif ()
+
 ## this hits with optimized builds somewhere in ftleaf_split, we don't
 ## know why but we don't think it's a big deal
 set_cflags_if_supported(


### PR DESCRIPTION
[+] new option for cmake (-DPROFILING)
[+] added -fno-omit-frame-pointer by request from Vadim and turned it on only if -DPROFILING is set

tested 3 times to make sure it works:
1) without -DPROFILING. result - -fno-omit-frame-pointer is not set
2) with -DPROFILING=on. result - -fno-omit-frame-pointer is set
3) with -DPROFILING=off. result - -fno-omit-frame-pointer is not set