### PR TITLE
fix memory leak found with address sanitizer.  for some reason, c…

### DIFF
--- a/ft/tests/bnc-insert-benchmark.cc
+++ b/ft/tests/bnc-insert-benchmark.cc
@@ -59,9 +59,10 @@ static void
 run_test(unsigned long eltsize, unsigned long nodesize, unsigned long repeat)
 {
     int cur = 0;
-    long keys[1024];
-    char *vals[1024];
-    for (int i = 0; i < 1024; ++i) {
+    const int n = 1024;
+    long keys[n];
+    char *vals[n];
+    for (int i = 0; i < n; ++i) {
         keys[i] = rand();
         XMALLOC_N(eltsize - (sizeof keys[i]), vals[i]);
         unsigned int j = 0;
@@ -92,14 +93,21 @@ run_test(unsigned long eltsize, unsigned long nodesize, unsigned long repeat)
         bnc = toku_create_empty_nl();
         for (; toku_bnc_nbytesinbuf(bnc) <= nodesize; ++cur) {
             toku_bnc_insert_msg(bnc,
-                                &keys[cur % 1024], sizeof keys[cur % 1024],
-                                vals[cur % 1024], eltsize - (sizeof keys[cur % 1024]),
+                                &keys[cur % n], sizeof keys[cur % n],
+                                vals[cur % n], eltsize - (sizeof keys[cur % n]),
                                 FT_NONE, next_dummymsn(), xids_123, true,
                                 cmp); assert_zero(r);
         }
         nbytesinserted += toku_bnc_nbytesinbuf(bnc);
         destroy_nonleaf_childinfo(bnc);
     }
+
+    for (int i = 0; i < n; ++i) {
+        toku_free(vals[i]);
+        vals[i] = nullptr;
+    }
+
+    toku_xids_destroy(&xids_123);
 
     gettimeofday(&t[1], NULL);
     double dt;


### PR DESCRIPTION
…test -DExperimentalMemCheck does not run the

    bnc-insert test with valgrind.

    Copyright (c) 2015, Rich Prohaska
    All rights reserved.

    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribu

    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS