### PR TITLE
fix memory leak due to data race in context status initialization.

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -4323,6 +4323,7 @@ int toku_ft_layer_init(void) {
 
     partitioned_counters_init();
     toku_status_init();
+    toku_context_status_init();
     toku_checkpoint_init();
     toku_ft_serialize_layer_init();
     toku_mutex_init(&ft_open_close_lock, NULL);

--- a/util/context.cc
+++ b/util/context.cc
@@ -70,8 +70,7 @@ const toku::context *toku_thread_get_context() {
 static struct context_status context_status;
 #define CONTEXT_STATUS_INIT(key, legend) TOKUFT_STATUS_INIT(context_status, key, nullptr, PARCOUNT, "context: " legend, TOKU_ENGINE_STATUS)
 
-static void
-context_status_init(void) {
+void toku_context_status_init(void) {
     CONTEXT_STATUS_INIT(CTX_SEARCH_BLOCKED_BY_FULL_FETCH,           "tree traversals blocked by a full fetch");
     CONTEXT_STATUS_INIT(CTX_SEARCH_BLOCKED_BY_PARTIAL_FETCH,        "tree traversals blocked by a partial fetch");
     CONTEXT_STATUS_INIT(CTX_SEARCH_BLOCKED_BY_FULL_EVICTION,        "tree traversals blocked by a full eviction");
@@ -96,18 +95,14 @@ context_status_init(void) {
 #undef FS_STATUS_INIT
 
 void toku_context_get_status(struct context_status *status) {
-    if (!context_status.initialized) {
-        context_status_init();
-    }
+    assert(context_status.initialized);
     *status = context_status;
 }
 
 #define STATUS_INC(x, d) increment_partitioned_counter(context_status.status[x].value.parcount, d);
 
 void toku_context_note_frwlock_contention(const context_id blocked, const context_id blocking) {
-    if (!context_status.initialized) {
-        context_status_init();
-    }
+    assert(context_status.initialized);
     if (blocked != CTX_SEARCH && blocked != CTX_PROMO) {
         // Return early if this event is "unknown"
         STATUS_INC(CTX_BLOCKED_OTHER, 1);

--- a/util/context.h
+++ b/util/context.h
@@ -148,4 +148,5 @@ struct context_status {
 
 void toku_context_get_status(struct context_status *status);
 
+void toku_context_status_init(void);
 void toku_context_status_destroy(void);

--- a/util/tests/test-rwlock-cheapness.cc
+++ b/util/tests/test-rwlock-cheapness.cc
@@ -243,6 +243,7 @@ int main (int UU(argc), const char* UU(argv[])) {
     // and context because normally toku_ft_layer_init() does that
     // for us, but we don't want to initialize everything.
     partitioned_counters_init();
+    toku_context_status_init();
     test_write_cheapness();
     toku_context_status_destroy();
     partitioned_counters_destroy();


### PR DESCRIPTION
found by address sanitizer when running the FT stress tests.

Copyright (c) 2015, Rich Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribu

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS