### PR TITLE
    document the problems with the helgrind annotations of unsafe fetch and set .    generalize the unsafe fetch and set function names for helgrind, drd, and tsan.

### DIFF
--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -430,7 +430,9 @@ static void print_db_key_range_struct (void) {
 
 static void print_db_lsn_struct (void) {
     field_counter=0;
-    sort_and_dump_fields("db_lsn", false, NULL);
+    /* A dummy field to make sizeof(DB_LSN) equal in C and C++ */
+    const char *extra[] = { "char dummy", NULL };
+    sort_and_dump_fields("db_lsn", false, extra);
 }
 
 static void print_dbt_struct (void) {

--- a/ft/cachetable/cachetable.cc
+++ b/ft/cachetable/cachetable.cc
@@ -2425,7 +2425,7 @@ toku_cachetable_minicron_shutdown(CACHETABLE ct) {
 
 void toku_cachetable_prepare_close(CACHETABLE ct UU()) {
     extern bool toku_serialize_in_parallel;
-    toku_drd_unsafe_set(&toku_serialize_in_parallel, true);
+    toku_unsafe_set(&toku_serialize_in_parallel, true);
 }
 
 /* Requires that it all be flushed. */

--- a/ft/ft-flusher.cc
+++ b/ft/ft-flusher.cc
@@ -497,7 +497,7 @@ handle_split_of_child(
     // We never set the rightmost blocknum to be the root.
     // Instead, we wait for the root to split and let promotion initialize the rightmost
     // blocknum to be the first non-root leaf node on the right extreme to recieve an insert.
-    BLOCKNUM rightmost_blocknum = toku_drd_unsafe_fetch(&ft->rightmost_blocknum);
+    BLOCKNUM rightmost_blocknum = toku_unsafe_fetch(&ft->rightmost_blocknum);
     invariant(ft->h->root_blocknum.b != rightmost_blocknum.b);
     if (childa->blocknum.b == rightmost_blocknum.b) {
         // The rightmost leaf (a) split into (a) and (b). We want (b) to swap pair values
@@ -1326,7 +1326,7 @@ ft_merge_child(
             node->pivotkeys.delete_at(childnuma);
 
             // Handle a merge of the rightmost leaf node.
-            BLOCKNUM rightmost_blocknum = toku_drd_unsafe_fetch(&ft->rightmost_blocknum); 
+            BLOCKNUM rightmost_blocknum = toku_unsafe_fetch(&ft->rightmost_blocknum);
             if (did_merge && childb->blocknum.b == rightmost_blocknum.b) {
                 invariant(childb->blocknum.b != ft->h->root_blocknum.b);
                 toku_ftnode_swap_pair_values(childa, childb);

--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -988,7 +988,7 @@ exit:
 // We need a function to have something a drd suppression can reference
 // see src/tests/drd.suppressions (unsafe_touch_clock)
 static void unsafe_touch_clock(FTNODE node, int i) {
-    toku_drd_unsafe_set(&node->bp[i].clock_count, static_cast<unsigned char>(1));
+    toku_unsafe_set(&node->bp[i].clock_count, static_cast<unsigned char>(1));
 }
 
 // Callback that states if a partial fetch of the node is necessary
@@ -1408,13 +1408,13 @@ static void inject_message_in_locked_node(
     paranoid_invariant(msg_with_msn.msn().msn == node->max_msn_applied_to_node_on_disk.msn);
 
     if (node->blocknum.b == ft->rightmost_blocknum.b) {
-        if (toku_drd_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
+        if (toku_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
             // we promoted to the rightmost leaf node and the seqinsert score has not yet saturated.
             toku_sync_fetch_and_add(&ft->seqinsert_score, 1);
         }
-    } else if (toku_drd_unsafe_fetch(&ft->seqinsert_score) != 0) {
+    } else if (toku_unsafe_fetch(&ft->seqinsert_score) != 0) {
         // we promoted to something other than the rightmost leaf node and the score should reset
-        toku_drd_unsafe_set(&ft->seqinsert_score, static_cast<uint32_t>(0));
+        toku_unsafe_set(&ft->seqinsert_score, static_cast<uint32_t>(0));
     }
 
     // if we call toku_ft_flush_some_child, then that function unpins the root
@@ -1576,16 +1576,16 @@ static inline bool should_inject_in_node(seqinsert_loc loc, int height, int dept
 static void ft_verify_or_set_rightmost_blocknum(FT ft, BLOCKNUM b)
 // Given: 'b', the _definitive_ and constant rightmost blocknum of 'ft'
 {
-    if (toku_drd_unsafe_fetch(&ft->rightmost_blocknum.b) == RESERVED_BLOCKNUM_NULL) {
+    if (toku_unsafe_fetch(&ft->rightmost_blocknum.b) == RESERVED_BLOCKNUM_NULL) {
         toku_ft_lock(ft);
         if (ft->rightmost_blocknum.b == RESERVED_BLOCKNUM_NULL) {
-            toku_drd_unsafe_set(&ft->rightmost_blocknum, b);
+            toku_unsafe_set(&ft->rightmost_blocknum, b);
         }
         toku_ft_unlock(ft);
     }
     // The rightmost blocknum only transitions from RESERVED_BLOCKNUM_NULL to non-null.
     // If it's already set, verify that the stored value is consistent with 'b'
-    invariant(toku_drd_unsafe_fetch(&ft->rightmost_blocknum.b) == b.b);
+    invariant(toku_unsafe_fetch(&ft->rightmost_blocknum.b) == b.b);
 }
 
 bool toku_bnc_should_promote(FT ft, NONLEAF_CHILDINFO bnc) {
@@ -2069,7 +2069,7 @@ static int ft_maybe_insert_into_rightmost_leaf(FT ft, DBT *key, DBT *val, XIDS m
 
     // Don't do the optimization if our heurstic suggests that
     // insertion pattern is not sequential.
-    if (toku_drd_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
+    if (toku_unsafe_fetch(&ft->seqinsert_score) < FT_SEQINSERT_SCORE_THRESHOLD) {
         goto cleanup;
     }
 

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -92,7 +92,7 @@ struct toku_thread_pool *get_ft_pool(void) {
 }
 
 void toku_serialize_set_parallel(bool in_parallel) {
-    toku_drd_unsafe_set(&toku_serialize_in_parallel, in_parallel);
+    toku_unsafe_set(&toku_serialize_in_parallel, in_parallel);
 }
 
 void toku_ft_serialize_layer_init(void) {
@@ -799,7 +799,7 @@ toku_serialize_ftnode_to (int fd, BLOCKNUM blocknum, FTNODE node, FTNODE_DISK_DA
         ft->h->basementnodesize,
         ft->h->compression_method,
         do_rebalancing,
-        toku_drd_unsafe_fetch(&toku_serialize_in_parallel),
+        toku_unsafe_fetch(&toku_serialize_in_parallel),
         &n_to_write,
         &n_uncompressed_bytes,
         &compressed_buf

--- a/ft/txn/txn.cc
+++ b/ft/txn/txn.cc
@@ -178,7 +178,7 @@ toku_txn_begin_with_xid (
         // this call will set txn->xids
         txn_create_xids(txn, parent);
     }
-    toku_drd_unsafe_set(txnp, txn);
+    toku_unsafe_set(txnp, txn);
 exit:
     return r;
 }

--- a/ft/txn/txn_manager.cc
+++ b/ft/txn/txn_manager.cc
@@ -287,7 +287,7 @@ toku_txn_manager_get_oldest_living_xid(TXN_MANAGER txn_manager) {
 }
 
 TXNID toku_txn_manager_get_oldest_referenced_xid_estimate(TXN_MANAGER txn_manager) {
-    return toku_drd_unsafe_fetch(&txn_manager->last_calculated_oldest_referenced_xid);
+    return toku_unsafe_fetch(&txn_manager->last_calculated_oldest_referenced_xid);
 }
 
 int live_root_txn_list_iter(const TOKUTXN &live_xid, const uint32_t UU(index), TXNID **const referenced_xids);
@@ -347,7 +347,7 @@ static void set_oldest_referenced_xid(TXN_MANAGER txn_manager) {
         oldest_referenced_xid = txn_manager->last_xid;
     }
     invariant(oldest_referenced_xid != TXNID_MAX);
-    toku_drd_unsafe_set(&txn_manager->last_calculated_oldest_referenced_xid, oldest_referenced_xid);
+    toku_unsafe_set(&txn_manager->last_calculated_oldest_referenced_xid, oldest_referenced_xid);
 }
 
 //Heaviside function to find a TOKUTXN by TOKUTXN (used to find the index)

--- a/portability/toku_race_tools.h
+++ b/portability/toku_race_tools.h
@@ -94,42 +94,51 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #endif
 
-namespace data_race {
+// Valgrind 3.10.1 (and previous versions).
+// Problems with VALGRIND_HG_DISABLE_CHECKING and VALGRIND_HG_ENABLE_CHECKING.
+// Helgrind's implementation of disable and enable checking causes false races to be
+// reported.  In addition, the race report does not include ANY information about
+// the code that uses the helgrind disable and enable functions.  Therefore, it is
+// very difficult to figure out the cause of the race.
+// DRD does implement the disable and enable functions.
 
-    template<typename T>
-    class unsafe_read {
-        const T &_val;
-    public:
-        unsafe_read(const T &val)
-            : _val(val) {
-            TOKU_VALGRIND_HG_DISABLE_CHECKING(&_val, sizeof _val);
-            TOKU_ANNOTATE_IGNORE_READS_BEGIN();
-        }
-        ~unsafe_read() {
-            TOKU_ANNOTATE_IGNORE_READS_END();
-            TOKU_VALGRIND_HG_ENABLE_CHECKING(&_val, sizeof _val);
-        }
-        operator T() const {
-            return _val;
-        }
-    };
+// Problems with ANNOTATE_IGNORE_READS.
+// Helgrind does not implement ignore reads.
+// Annotate ignore reads is the way to inform DRD to ignore racy reads.
 
-} // namespace data_race
+// FT code uses unsafe reads in several places.  These unsafe reads have been noted
+// as valid since they use the toku_unsafe_fetch function. Unfortunately, this
+// causes helgrind to report erroneous data races which makes use of helgrind problematic.
 
 // Unsafely fetch and return a `T' from src, telling drd to ignore 
 // racey access to src for the next sizeof(*src) bytes
 template <typename T>
-T toku_drd_unsafe_fetch(T *src) {
-    return data_race::unsafe_read<T>(*src);
+T toku_unsafe_fetch(T *src) {
+    if (0) TOKU_VALGRIND_HG_DISABLE_CHECKING(src, sizeof *src); // disabled, see comment
+    TOKU_ANNOTATE_IGNORE_READS_BEGIN();
+    T r = *src;
+    TOKU_ANNOTATE_IGNORE_READS_END();
+    if (0) TOKU_VALGRIND_HG_ENABLE_CHECKING(src, sizeof *src); // disabled, see comment
+    return r;
+}
+
+template <typename T>
+T toku_unsafe_fetch(T &src) {
+    return toku_unsafe_fetch(&src);
 }
 
 // Unsafely set a `T' value into *dest from src, telling drd to ignore 
 // racey access to dest for the next sizeof(*dest) bytes
 template <typename T>
-void toku_drd_unsafe_set(T *dest, const T src) {
-    TOKU_VALGRIND_HG_DISABLE_CHECKING(dest, sizeof *dest);
+void toku_unsafe_set(T *dest, const T src) {
+    if (0) TOKU_VALGRIND_HG_DISABLE_CHECKING(dest, sizeof *dest); // disabled, see comment
     TOKU_ANNOTATE_IGNORE_WRITES_BEGIN();
     *dest = src;
     TOKU_ANNOTATE_IGNORE_WRITES_END();
-    TOKU_VALGRIND_HG_ENABLE_CHECKING(dest, sizeof *dest);
+    if (0) TOKU_VALGRIND_HG_ENABLE_CHECKING(dest, sizeof *dest); // disabled, see comment
+}
+
+template <typename T>
+void toku_unsafe_set(T &dest, const T src) {
+    toku_unsafe_set(&dest, src);
 }

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -174,7 +174,6 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
 
   declare_custom_tests(test_groupcommit_count.tdb)
   add_ydb_test(test_groupcommit_count.tdb -n 1)
-  add_ydb_helgrind_test(test_groupcommit_count.tdb -n 2)
   add_ydb_drd_test(test_groupcommit_count.tdb -n 2)
 
   add_ydb_drd_test(test_4015.tdb)


### PR DESCRIPTION
    document the problems with the helgrind annotations of unsafe fetch and set
    generalize the unsafe fetch and set function names for helgrind, drd, and tsan.
    
    Copyright (c) 2015, Rich Prohaska
    All rights reserved.
    
    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
    
    1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
    
    2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the dist
    
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITN
