### PR TITLE
compile with clang-3.8

### DIFF
--- a/util/dmt.cc
+++ b/util/dmt.cc
@@ -870,42 +870,26 @@ void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::rebalance(subtree *const subtree
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t *const out, const dmt_node *const n) {
-    if (outlen) {
-        *outlen = n->value_length;
-    }
-    if (out) {
-        *out = n->value;
-    }
+    *outlen = n->value_length;
+    *out = n->value;
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t **const out, dmt_node *const n) {
-    if (outlen) {
-        *outlen = n->value_length;
-    }
-    if (out) {
-        *out = &n->value;
-    }
+    *outlen = n->value_length;
+    *out = &n->value;
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t *const out, const uint32_t len, const dmtdata_t *const stored_value_ptr) {
-    if (outlen) {
-        *outlen = len;
-    }
-    if (out) {
-        *out = *stored_value_ptr;
-    }
+    *outlen = len;
+    *out = *stored_value_ptr;
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t **const out, const uint32_t len, dmtdata_t *const stored_value_ptr) {
-    if (outlen) {
-        *outlen = len;
-    }
-    if (out) {
-        *out = stored_value_ptr;
-    }
+    *outlen = len;
+    *out = stored_value_ptr;
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>


### PR DESCRIPTION
remove extraneous null pointer checks since functions are annotated as nonnull.
Copyright (c) 2015, Rich Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.