### PR TITLE
DB-833 tokudb broken after 'create database log002015'

### DIFF
--- a/ft/logger/logger.cc
+++ b/ft/logger/logger.cc
@@ -75,10 +75,10 @@ static void toku_print_bytes (FILE *outf, uint32_t len, char *data) {
 
 static bool is_a_logfile_any_version (const char *name, uint64_t *number_result, uint32_t *version_of_log) {
     bool rval = true;
-    uint64_t result;
-    int n;
+    uint64_t result = 0UL;
+    int n = 0;
     int r;
-    uint32_t version;
+    uint32_t version = 0;
     r = sscanf(name, "log%" SCNu64 ".tokulog%" SCNu32 "%n", &result, &version, &n);
     if (r!=2 || name[n]!='\0' || version <= TOKU_LOG_VERSION_1) {
         //Version 1 does NOT append 'version' to end of '.tokulog'
@@ -644,6 +644,11 @@ int toku_logger_find_logfiles (const char *directory, char ***resultp, int *n_lo
     while ((de=readdir(d))) {
         uint64_t thisl;
         uint32_t version_ignore;
+
+        // if de is directory, skip it
+        if (de->d_type == DT_DIR)
+            continue;
+
         if ( !(is_a_logfile_any_version(de->d_name, &thisl, &version_ignore)) ) continue; //#2424: Skip over files that don't match the exact logfile template
         if (n_results+1>=result_limit) {
             result_limit*=2;


### PR DESCRIPTION
[summary]
In is_a_logfile_any_version, the uninitialized variable is terrible when we complied with -O3 flag, if we have a directory named 'log02015', 'n' is undefined value after sscanf

Copyright (c) 2015, BohuTANG
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.