### PR TITLE
Returned null pointer checks in DMT and turned off problematic clang flags.

### DIFF
--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -188,6 +188,16 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   set_cflags_if_supported(-Wcast-align)
 endif ()
 
+## Clang's pointer comparison warnings create false
+## negatives when instantiating templates that are
+## sometimes instantiated with null pointers and
+## other times with non-null local variable addresses.
+## The DMT implementation and test are examples.
+if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+   set_cflags_if_supported(-Wno-tautological-pointer-compare)
+   set_cflags_if_supported(-Wno-pointer-bool-conversion)
+endif()
+
 ## always want these
 set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "-Wall -Werror ${CMAKE_CXX_FLAGS}")

--- a/util/dmt.cc
+++ b/util/dmt.cc
@@ -870,26 +870,42 @@ void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::rebalance(subtree *const subtree
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t *const out, const dmt_node *const n) {
-    *outlen = n->value_length;
-    *out = n->value;
+    if (outlen) {
+        *outlen = n->value_length;
+    }
+    if (out) {
+        *out = n->value;
+    }
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t **const out, dmt_node *const n) {
-    *outlen = n->value_length;
-    *out = &n->value;
+    if (outlen) {
+        *outlen = n->value_length;
+    }
+    if (out) {
+        *out = &n->value;
+    }
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t *const out, const uint32_t len, const dmtdata_t *const stored_value_ptr) {
-    *outlen = len;
-    *out = *stored_value_ptr;
+    if (outlen) {
+        *outlen = len;
+    }
+    if (out) {
+        *out = *stored_value_ptr;
+    }
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>
 void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::copyout(uint32_t *const outlen, dmtdata_t **const out, const uint32_t len, dmtdata_t *const stored_value_ptr) {
-    *outlen = len;
-    *out = stored_value_ptr;
+    if (outlen) {
+        *outlen = len;
+    }
+    if (out) {
+        *out = stored_value_ptr;
+    }
 }
 
 template<typename dmtdata_t, typename dmtdataout_t, typename dmtwriter_t>


### PR DESCRIPTION
The recent commit to remove null checks and make the clang warnings (as errors) go away needs to be reverted. It has broken some tests, including the main DMT test.

Background: The production code instantiates the DMT with pointer types that are never null, which triggers the warning about the justifiably unnecessary checks.  However, the DMT test DOES instantiate the template with NULL-able arguments.  Presumably Clang doesn't make an exception for templates whose instantiation is potentially ambiguous with respect to null-able types...

So removing the checks from the code removes the warnings but breaks the test.  So, instead, we just disable those two warnings for clang only.  If this issue ever gets resolved we can re-enable them.

The other option is to remove all the null-able arguments from the associated tests, but that requires refactoring of various paths within the DMT template, which causes an arguably unnecessary amount of churn for suppressing a compiler warning.... Hence this solution.