### PR TITLE
fix uninitialized variable in xz compressor that causes compress-test to fail memcheck

### DIFF
--- a/third_party/xz-4.999.9beta/src/liblzma/lz/lz_encoder.c
+++ b/third_party/xz-4.999.9beta/src/liblzma/lz/lz_encoder.c
@@ -501,7 +501,10 @@ lzma_lz_encoder_init(lzma_next_coder *next, lzma_allocator *allocator,
 		next->coder->lz.end = NULL;
 
 		next->coder->mf.buffer = NULL;
+                next->coder->mf.size = 0;
 		next->coder->mf.hash = NULL;
+                next->coder->mf.hash_size_sum = 0;
+                next->coder->mf.sons_count = 0;
 
 		next->coder->next = LZMA_NEXT_CODER_INIT;
 	}


### PR DESCRIPTION
compress-test fails with valgrind due to conditional jump depended on an uninitialized value.  the uninitialized value occurs because the lzma encoder object is not fully initialized by its constructor.  the bug fix is to initialize the variables in the encoder's constructor.  see http://prohaska7.blogspot.com/2015/11/uninitialized-data-problem-in-lzma.html for details.

the test is to run 'make check' on the third party xz software.

the alternative fix is to add valgrind suppressions for the errors.

note that the fix has been made to the head of the xz git repo http://git.tukaani.org/?p=xz.git;a=summary to be release in some version post v5.2.2.

tokuft currently includes xz version 4.999.9beta from Aug 2009.  perhaps tokuft should either use lzma system library (whatever version) or update to the latest version.

here is the valgrind report:

==2368== Conditional jump or move depends on uninitialised value(s)
==2368==    at 0x4F5F21D: lz_encoder_prepare (lz_encoder.c:222)
==2368==    by 0x4F5F8DA: lzma_lz_encoder_init (lz_encoder.c:516)
==2368==    by 0x4F5F0CE: lzma_raw_coder_init (filter_common.c:212)
==2368==    by 0x4F52FF1: block_encode_normal (block_buffer_encoder.c:192)
==2368==    by 0x4F52FF1: lzma_block_buffer_encode (block_buffer_encoder.c:258)
==2368==    by 0x4F4F63D: lzma_stream_buffer_encode (stream_buffer_encoder.c:93)
==2368==    by 0x4F4F4A3: lzma_easy_buffer_encode (easy_buffer_encoder.c:27)
==2368==    by 0x4F046E9: toku_compress(toku_compression_method, unsigned char*, unsigned long*, unsigned char const*, unsigned long) (compress.cc:141)
==2368==    by 0x4022A7: test_compress_buf_method(unsigned char*, int, toku_compression_method) (compress-test.cc:54)
==2368==    by 0x4023B4: test_compress_i(int, toku_compression_method, unsigned long*, unsigned long*) (compress-test.cc:66)
==2368==    by 0x4024E8: test_compress(toku_compression_method, unsigned long*, unsigned long*) (compress-test.cc:83)
==2368==    by 0x402841: test_compress_methods() (compress-test.cc:123)
==2368==    by 0x402A13: test_main(int, char const**) (compress-test.cc:142)
==2368==    by 0x4021DB: main (test.h:346)
==2368==
==2368== Conditional jump or move depends on uninitialised value(s)
==2368==    at 0x4F5F32D: lz_encoder_prepare (lz_encoder.c:344)
==2368==    by 0x4F5F8DA: lzma_lz_encoder_init (lz_encoder.c:516)
==2368==    by 0x4F5F0CE: lzma_raw_coder_init (filter_common.c:212)
==2368==    by 0x4F52FF1: block_encode_normal (block_buffer_encoder.c:192)
==2368==    by 0x4F52FF1: lzma_block_buffer_encode (block_buffer_encoder.c:258)
==2368==    by 0x4F4F63D: lzma_stream_buffer_encode (stream_buffer_encoder.c:93)
==2368==    by 0x4F4F4A3: lzma_easy_buffer_encode (easy_buffer_encoder.c:27)
==2368==    by 0x4F046E9: toku_compress(toku_compression_method, unsigned char*, unsigned long*, unsigned char const*, unsigned long) (compress.cc:141)
==2368==    by 0x4022A7: test_compress_buf_method(unsigned char*, int, toku_compression_method) (compress-test.cc:54)
==2368==    by 0x4023B4: test_compress_i(int, toku_compression_method, unsigned long*, unsigned long*) (compress-test.cc:66)
==2368==    by 0x4024E8: test_compress(toku_compression_method, unsigned long*, unsigned long*) (compress-test.cc:83)
==2368==    by 0x402841: test_compress_methods() (compress-test.cc:123)
==2368==    by 0x402A13: test_main(int, char const**) (compress-test.cc:142)
==2368==    by 0x4021DB: main (test.h:346)
==2368==

Copyright (c) 2015, Rich Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
