### PR TITLE
Replace error to warning if transparent huge pages are enabled

### DIFF
--- a/buildheader/db-4.6.19.h
+++ b/buildheader/db-4.6.19.h
@@ -1717,7 +1717,7 @@ struct __db {
 		__P((DB *, int (*)(DB *, const DBT *, const DBT *)));
 	int  (*set_encrypt) __P((DB *, const char *, uint32_t));
 	void (*set_errcall) __P((DB *,
-		void (*)(const DB_ENV *, const char *, const char *)));
+		void (*)(const DB_ENV *, const char *, const char *, bool)));
 	void (*set_errfile) __P((DB *, FILE *));
 	void (*set_errpfx) __P((DB *, const char *));
 	int  (*set_feedback) __P((DB *, void (*)(DB *, int, int)));
@@ -2406,7 +2406,7 @@ struct __db_env {
 	int  (*set_data_dir) __P((DB_ENV *, const char *));
 	int  (*set_encrypt) __P((DB_ENV *, const char *, uint32_t));
 	void (*set_errcall) __P((DB_ENV *,
-		void (*)(const DB_ENV *, const char *, const char *)));
+		void (*)(const DB_ENV *, const char *, const char *, bool)));
 	void (*set_errfile) __P((DB_ENV *, FILE *));
 	void (*set_errpfx) __P((DB_ENV *, const char *));
 	int  (*set_event_notify)

--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -337,10 +337,10 @@ static void print_db_env_struct (void) {
     STRUCT_SETUP(DB_ENV, set_cachesize, "int  (*%s) (DB_ENV *, uint32_t, uint32_t, int)");
     STRUCT_SETUP(DB_ENV, set_data_dir, "int  (*%s) (DB_ENV *, const char *)");
 #if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 1
-    STRUCT_SETUP(DB_ENV, set_errcall, "void (*%s) (DB_ENV *, void (*)(const char *, char *))");
+    STRUCT_SETUP(DB_ENV, set_errcall, "void (*%s) (DB_ENV *, void (*)(const char *, char *, bool))");
 #endif
 #if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 3
-    STRUCT_SETUP(DB_ENV, set_errcall, "void (*%s) (DB_ENV *, void (*)(const DB_ENV *, const char *, const char *))");
+    STRUCT_SETUP(DB_ENV, set_errcall, "void (*%s) (DB_ENV *, void (*)(const DB_ENV *, const char *, const char *, bool))");
 #endif
     STRUCT_SETUP(DB_ENV, set_errfile, "void (*%s) (DB_ENV *, FILE*)");
     STRUCT_SETUP(DB_ENV, set_errpfx, "void (*%s) (DB_ENV *, const char *)");

--- a/src/errors.cc
+++ b/src/errors.cc
@@ -109,7 +109,7 @@ void toku_ydb_error_all_cases(const DB_ENV * env,
     }
 
     /* Print via errcall */
-    if (env->i->errcall) env->i->errcall(env, env->i->errpfx, buf);
+    if (env->i->errcall) env->i->errcall(env, env->i->errpfx, buf, error != TOKUDB_HUGE_PAGES_ENABLED);
 
     /* Print out on a file */
     toku__ydb_error_file(env, use_stderr_if_nothing_else, buf);

--- a/src/tests/test_error.cc
+++ b/src/tests/test_error.cc
@@ -47,7 +47,7 @@ char const* expect_errpfx;
 int n_handle_error=0;
 
 static void
-handle_error (const DB_ENV *UU(dbenv), const char *errpfx, const char *UU(msg)) {
+handle_error (const DB_ENV *UU(dbenv), const char *errpfx, const char *UU(msg), bool) {
     assert(errpfx==expect_errpfx);
     n_handle_error++;
 }

--- a/src/ydb-internal.h
+++ b/src/ydb-internal.h
@@ -73,9 +73,9 @@ int toku_db_set_indexer(DB *db, DB_INDEXER *indexer);
 DB_INDEXER *toku_db_get_indexer(DB *db);
 
 #if DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR == 1
-typedef void (*toku_env_errcall_t)(const char *, char *);
+typedef void (*toku_env_errcall_t)(const char *, char *, bool);
 #elif DB_VERSION_MAJOR == 4 && DB_VERSION_MINOR >= 3
-typedef void (*toku_env_errcall_t)(const DB_ENV *, const char *, const char *);
+typedef void (*toku_env_errcall_t)(const DB_ENV *, const char *, const char *, bool);
 #else
 #error
 #endif

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -768,11 +768,10 @@ env_open(DB_ENV * env, const char *home, uint32_t flags, int mode) {
         goto cleanup;
     }
 
-    if (toku_os_huge_pages_enabled()) {
+    // Issue warning if huge pages are enabled and continue
+    if (toku_os_huge_pages_enabled())
         r = toku_ydb_do_error(env, TOKUDB_HUGE_PAGES_ENABLED,
-                              "Huge pages are enabled, disable them before continuing\n");
-        goto cleanup;
-    }
+                              "Huge pages are enabled, disable them for optimal memory usage\n");
 
     most_recent_env = NULL;
 


### PR DESCRIPTION
1. Error handle callback now has one more parameter which signals about if the message is error or warning.

2. Call error handle hook with "warning" parameter if the error is TOKUDB_HUGE_PAGES_ENABLED.

http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1118/
http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/141/