### PR TITLE
build FT with clang 3.9.0 and fix broken tests

### DIFF
--- a/ft/serialize/rbtree_mhs.cc
+++ b/ft/serialize/rbtree_mhs.cc
@@ -397,7 +397,7 @@ namespace MhsRbTree {
                         pred, succ, pair, left_merge, right_merge, false);
                 } else {
                     // construct the node
-                    Node::Pair mhsp = {._left = 0, ._right = 0};
+                    Node::Pair mhsp {0, 0};
                     node =
                         new Node(EColor::BLACK, pair, mhsp, nullptr, nullptr, nullptr);
                     if (!node)
@@ -417,7 +417,7 @@ namespace MhsRbTree {
                         pred, succ, pair, left_merge, right_merge, true);
                 } else {
                     // construct the node
-                    Node::Pair mhsp = {._left = 0, ._right = 0};
+                    Node::Pair mhsp {0, 0};
                     node =
                         new Node(EColor::BLACK, pair, mhsp, nullptr, nullptr, nullptr);
                     if (!node)
@@ -428,7 +428,7 @@ namespace MhsRbTree {
                 }
             }
         } else {
-            Node::Pair mhsp = {._left = 0, ._right = 0};
+            Node::Pair mhsp {0, 0};
             node = new Node(EColor::BLACK, pair, mhsp, nullptr, nullptr, nullptr);
             if (!node)
                 return -1;

--- a/ft/tests/test-rbtree-insert-remove-without-mhs.cc
+++ b/ft/tests/test-rbtree-insert-remove-without-mhs.cc
@@ -89,6 +89,7 @@ static void test_insert_remove(void) {
     }
 
     tree->Destroy();
+    delete tree;
 }
 
 int test_main(int argc, const char *argv[]) {


### PR DESCRIPTION
build FT with clang 3.9.0.  change node pair initializer.

fix memory leak in rbtree test found with clang 3.9.0 ASAN.
253:     #0 0x503910 in operator new(unsigned long) /home/rfp/projects/llvm/projects/compiler-rt/lib/asan/asan_new_delete.cc:78
253:     #1 0x507137 in test_insert_remove() /home/rfp/projects/tokuft.clang39/ft/tests/test-rbtree-insert-remove-without-mhs.cc:66:29
253:     #2 0x506ebf in test_main(int, char const**) /home/rfp/projects/tokuft.clang39/ft/tests/test-rbtree-insert-remove-without-mhs.cc:98:5

Copyright (c) 2016, Rich Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.

2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distributio\
n.

THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR\
 A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT N\
OT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, \
OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

