### PR TITLE
FT-732 : logical row counts inaccurate

### DIFF
--- a/ft/ft.cc
+++ b/ft/ft.cc
@@ -903,6 +903,9 @@ void toku_ft_adjust_logical_row_count(FT ft, int64_t delta) {
     // must be returned in toku_ft_stat64.
     if (delta != 0 && ft->in_memory_logical_rows != (uint64_t)-1) {
         toku_sync_fetch_and_add(&(ft->in_memory_logical_rows), delta);
+        if (ft->in_memory_logical_rows == (uint64_t)-1) {
+            toku_sync_fetch_and_add(&(ft->in_memory_logical_rows), 1);
+        }
     }
 }
 

--- a/ft/node.h
+++ b/ft/node.h
@@ -199,6 +199,7 @@ struct ftnode_leaf_basement_node {
     MSN max_msn_applied;            // max message sequence number applied
     bool stale_ancestor_messages_applied;
     STAT64INFO_S stat64_delta;      // change in stat64 counters since basement was last written to disk
+    int64_t logical_rows_delta;
 };
 typedef struct ftnode_leaf_basement_node *BASEMENTNODE;
 

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -996,6 +996,7 @@ BASEMENTNODE toku_clone_bn(BASEMENTNODE orig_bn) {
     bn->seqinsert = orig_bn->seqinsert;
     bn->stale_ancestor_messages_applied = orig_bn->stale_ancestor_messages_applied;
     bn->stat64_delta = orig_bn->stat64_delta;
+    bn->logical_rows_delta = orig_bn->logical_rows_delta;
     bn->data_buffer.clone(&orig_bn->data_buffer);
     return bn;
 }
@@ -1006,6 +1007,7 @@ BASEMENTNODE toku_create_empty_bn_no_buffer(void) {
     bn->seqinsert = 0;
     bn->stale_ancestor_messages_applied = false;
     bn->stat64_delta = ZEROSTATS;
+    bn->logical_rows_delta = 0;
     bn->data_buffer.init_zero();
     return bn;
 }

--- a/src/tests/stat64-root-changes.cc
+++ b/src/tests/stat64-root-changes.cc
@@ -166,7 +166,7 @@ run_test (void) {
 
         DB_BTREE_STAT64 s;
         r = db->stat64(db, NULL, &s); CKERR(r);
-        assert(s.bt_nkeys == 0);
+        assert(s.bt_nkeys == 1);
 
         r = db->close(db, 0);     CKERR(r);
 
@@ -176,7 +176,7 @@ run_test (void) {
         r = txn->commit(txn, 0);    CKERR(r);
 
         r = db->stat64(db, NULL, &s); CKERR(r);
-        assert(s.bt_nkeys == 0);
+        assert(s.bt_nkeys == 1);
     }
 
     // verify update callback overwrites the row

--- a/tools/tokuftdump.cc
+++ b/tools/tokuftdump.cc
@@ -192,6 +192,7 @@ static void dump_header(FT ft) {
     dump_descriptor(&ft->descriptor);
     printf(" estimated numrows=%" PRId64 "\n", ft->in_memory_stats.numrows);
     printf(" estimated numbytes=%" PRId64 "\n", ft->in_memory_stats.numbytes);
+    printf(" logical row count=%" PRId64 "\n", ft->in_memory_logical_rows);
 }
 
 static int64_t getRootNode(FT ft) {


### PR DESCRIPTION
- Added mechanism to track adjustments made to logical row counts per node and undo those adjustments if the node is evicted without being persisted.
- Fixed counting of updates that get turned into insert messages.
- Fixed stat64 test that was incorrectly changed during initial logical row count testing.
- Formatting changes for each function touched.