### PR TITLE
FT-735 : test-rbtree-insert-remove-without-mhs fails mem test and val…

### DIFF
--- a/ft/serialize/rbtree_mhs.h
+++ b/ft/serialize/rbtree_mhs.h
@@ -106,6 +106,7 @@ namespace MhsRbTree {
         static const uint64_t MHS_MAX_VAL = 0xffffffffffffffff;
         OUUInt64() : _value(0) {}
         OUUInt64(uint64_t s) : _value(s) {}
+        OUUInt64(const OUUInt64& o) : _value(o._value) {}
         bool operator<(const OUUInt64 &r) const {
             invariant(!(_value == MHS_MAX_VAL && r.ToInt() == MHS_MAX_VAL));
             return _value < r.ToInt();
@@ -182,15 +183,18 @@ namespace MhsRbTree {
 
     class Node {
        public:
-        struct BlockPair {
+        class BlockPair {
+           public:
             OUUInt64 _offset;
             OUUInt64 _size;
 
             BlockPair() : _offset(0), _size(0) {}
             BlockPair(uint64_t o, uint64_t s) : _offset(o), _size(s) {}
-
             BlockPair(OUUInt64 o, OUUInt64 s) : _offset(o), _size(s) {}
-            int operator<(const struct BlockPair &rhs) const {
+            BlockPair(const BlockPair &o)
+                : _offset(o._offset), _size(o._size) {}
+
+            int operator<(const BlockPair &rhs) const {
                 return _offset < rhs._offset;
             }
             int operator<(const uint64_t &o) const { return _offset < o; }
@@ -203,15 +207,15 @@ namespace MhsRbTree {
         };
 
         EColor _color;
-        struct BlockPair _hole;
-        struct Pair _label;
+        BlockPair _hole;
+        Pair _label;
         Node *_left;
         Node *_right;
         Node *_parent;
 
         Node(EColor c,
              Node::BlockPair h,
-             struct Pair lb,
+             Pair lb,
              Node *l,
              Node *r,
              Node *p)

--- a/ft/tests/test-rbtree-insert-remove-without-mhs.cc
+++ b/ft/tests/test-rbtree-insert-remove-without-mhs.cc
@@ -53,9 +53,10 @@ static void generate_random_input() {
     std::srand(unsigned(std::time(0)));
 
     // set some values:
-    for (uint64_t i = 1; i < N; ++i) {
-        input_vector.push_back({i, 0});
-        old_vector[i] = {i, 0};
+    for (uint64_t i = 0; i < N; ++i) {
+        MhsRbTree::Node::BlockPair bp = {i+1, 0};
+        input_vector.push_back(bp);
+        old_vector[i] = bp;
     }
     // using built-in random generator:
     std::random_shuffle(input_vector.begin(), input_vector.end(), myrandom);


### PR DESCRIPTION
…grind test

- Fixed test to properly initialize test data and free allocated resources.