### PR TITLE
Partially fix FT-704 (Consider removing attribute((nonnull)) annotati…

### DIFF
--- a/util/dmt.h
+++ b/util/dmt.h
@@ -589,7 +589,6 @@ private:
 
     void convert_from_tree_to_array(void);
 
-    __attribute__((nonnull(2,5)))
     void delete_internal(subtree *const subtreep, const uint32_t idx, subtree *const subtree_replace, subtree **const rebalance_subtree);
 
     template<typename iterate_extra_t,
@@ -627,16 +626,12 @@ private:
     __attribute__((nonnull))
     void rebalance(subtree *const subtree);
 
-    __attribute__((nonnull))
     static void copyout(uint32_t *const outlen, dmtdata_t *const out, const dmt_node *const n);
 
-    __attribute__((nonnull))
     static void copyout(uint32_t *const outlen, dmtdata_t **const out, dmt_node *const n);
 
-    __attribute__((nonnull))
     static void copyout(uint32_t *const outlen, dmtdata_t *const out, const uint32_t len, const dmtdata_t *const stored_value_ptr);
 
-    __attribute__((nonnull))
     static void copyout(uint32_t *const outlen, dmtdata_t **const out, const uint32_t len, dmtdata_t *const stored_value_ptr);
 
     template<typename dmtcmp_t,

--- a/util/omt.h
+++ b/util/omt.h
@@ -284,7 +284,6 @@ public:
      *               By taking ownership of the array, we save a malloc and memcpy,
      *               and possibly a free (if the caller is done with the array).
      */
-    __attribute__((nonnull))
     void create_steal_sorted_array(omtdata_t **const values, const uint32_t numvalues, const uint32_t new_capacity);
 
     /**
@@ -667,7 +666,6 @@ private:
 
     void set_at_internal(const subtree &subtree, const omtdata_t &value, const uint32_t idx);
 
-    __attribute__((nonnull(2,5)))
     void delete_internal(subtree *const subtreep, const uint32_t idx, omt_node *const copyn, subtree **const rebalance_subtree);
 
     template<typename iterate_extra_t,


### PR DESCRIPTION
…ons)

GCC 6 has a new warning option -Wnonnull-compare that points out
conflicts between the nonnull annotations and actual code checking for
NULL values. Fix the warnings by removing the nonnull attributes.

http://jenkins.percona.com/view/TokuDB/job/PerconaFT-param/67/