### PR TITLE
FT-732 : logical row counts inaccurate

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -651,10 +651,8 @@ void toku_ftnode_clone_callback(void *value_data,
     // set new pair attr if necessary
     if (node->height == 0) {
         *new_attr = make_ftnode_pair_attr(node);
-        for (int i = 0; i < node->n_children; i++) {
-            BLB(node, i)->logical_rows_delta = 0;
-            BLB(cloned_node, i)->logical_rows_delta = 0;
-        }
+        node->logical_rows_delta = 0;
+        cloned_node->logical_rows_delta = 0;
     } else {
         new_attr->is_valid = false;
     }
@@ -702,6 +700,10 @@ void toku_ftnode_flush_callback(CACHEFILE UU(cachefile),
             if (ftnode->height == 0) {
                 FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF, 1);
                 FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF_BYTES, node_size);
+                if (!ftnode->dirty) {
+                    toku_ft_adjust_logical_row_count(
+                        ft, -ftnode->logical_rows_delta);
+                }
             } else {
                 FT_STATUS_INC(FT_FULL_EVICTIONS_NONLEAF, 1);
                 FT_STATUS_INC(FT_FULL_EVICTIONS_NONLEAF_BYTES, node_size);
@@ -714,10 +716,11 @@ void toku_ftnode_flush_callback(CACHEFILE UU(cachefile),
                         BASEMENTNODE bn = BLB(ftnode, i);
                         toku_ft_decrease_stats(&ft->in_memory_stats,
                                                bn->stat64_delta);
-                        if (!ftnode->dirty)
-                            toku_ft_adjust_logical_row_count(
-                                ft, -bn->logical_rows_delta);
                     }
+                }
+                if (!ftnode->dirty) {
+                    toku_ft_adjust_logical_row_count(
+                        ft, -ftnode->logical_rows_delta);
                 }
             }
         }
@@ -944,8 +947,6 @@ int toku_ftnode_pe_callback(void *ftnode_pv,
                     basements_to_destroy[num_basements_to_destroy++] = bn;
                     toku_ft_decrease_stats(&ft->in_memory_stats,
                                            bn->stat64_delta);
-                    toku_ft_adjust_logical_row_count(ft,
-                                                     -bn->logical_rows_delta);
                     set_BNULL(node, i);
                     BP_STATE(node, i) = PT_ON_DISK;
                     num_partial_evictions++;

--- a/ft/node.cc
+++ b/ft/node.cc
@@ -386,7 +386,8 @@ static void bnc_apply_messages_to_basement_node(
     const pivot_bounds &
         bounds,  // contains pivot key bounds of this basement node
     txn_gc_info *gc_info,
-    bool *msgs_applied) {
+    bool *msgs_applied,
+    int64_t* logical_rows_delta) {
     int r;
     NONLEAF_CHILDINFO bnc = BNC(ancestor, childnum);
 
@@ -394,7 +395,6 @@ static void bnc_apply_messages_to_basement_node(
     // apply messages from this buffer
     STAT64INFO_S stats_delta = {0, 0};
     uint64_t workdone_this_ancestor = 0;
-    int64_t logical_rows_delta = 0;
 
     uint32_t stale_lbi, stale_ube;
     if (!bn->stale_ancestor_messages_applied) {
@@ -470,7 +470,7 @@ static void bnc_apply_messages_to_basement_node(
                             gc_info,
                             &workdone_this_ancestor,
                             &stats_delta,
-                            &logical_rows_delta);
+                            logical_rows_delta);
         }
     } else if (stale_lbi == stale_ube) {
         // No stale messages to apply, we just apply fresh messages, and mark
@@ -482,7 +482,7 @@ static void bnc_apply_messages_to_basement_node(
             .gc_info = gc_info,
             .workdone = &workdone_this_ancestor,
             .stats_to_update = &stats_delta,
-            .logical_rows_delta = &logical_rows_delta};
+            .logical_rows_delta = logical_rows_delta};
         if (fresh_ube - fresh_lbi > 0)
             *msgs_applied = true;
         r = bnc->fresh_message_tree
@@ -503,7 +503,7 @@ static void bnc_apply_messages_to_basement_node(
             .gc_info = gc_info,
             .workdone = &workdone_this_ancestor,
             .stats_to_update = &stats_delta,
-            .logical_rows_delta = &logical_rows_delta};
+            .logical_rows_delta = logical_rows_delta};
 
         r = bnc->stale_message_tree
                 .iterate_on_range<struct iterate_do_bn_apply_msg_extra,
@@ -521,8 +521,6 @@ static void bnc_apply_messages_to_basement_node(
     if (stats_delta.numbytes || stats_delta.numrows) {
         toku_ft_update_stats(&t->ft->in_memory_stats, stats_delta);
     }
-    toku_ft_adjust_logical_row_count(t->ft, logical_rows_delta);
-    bn->logical_rows_delta += logical_rows_delta;
 }
 
 static void
@@ -536,6 +534,7 @@ apply_ancestors_messages_to_bn(
     bool* msgs_applied
     )
 {
+    int64_t logical_rows_delta = 0;
     BASEMENTNODE curr_bn = BLB(node, childnum);
     const pivot_bounds curr_bounds = bounds.next_bounds(node, childnum);
     for (ANCESTORS curr_ancestors = ancestors; curr_ancestors; curr_ancestors = curr_ancestors->next) {
@@ -548,13 +547,16 @@ apply_ancestors_messages_to_bn(
                 curr_ancestors->childnum,
                 curr_bounds,
                 gc_info,
-                msgs_applied
+                msgs_applied,
+                &logical_rows_delta
                 );
             // We don't want to check this ancestor node again if the
             // next time we query it, the msn hasn't changed.
             curr_bn->max_msn_applied = curr_ancestors->node->max_msn_applied_to_node_on_disk;
         }
     }
+    toku_ft_adjust_logical_row_count(t->ft, logical_rows_delta);
+    node->logical_rows_delta += logical_rows_delta;
     // At this point, we know all the stale messages above this
     // basement node have been applied, and any new messages will be
     // fresh, so we don't need to look at stale messages for this

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -996,7 +996,6 @@ BASEMENTNODE toku_clone_bn(BASEMENTNODE orig_bn) {
     bn->seqinsert = orig_bn->seqinsert;
     bn->stale_ancestor_messages_applied = orig_bn->stale_ancestor_messages_applied;
     bn->stat64_delta = orig_bn->stat64_delta;
-    bn->logical_rows_delta = orig_bn->logical_rows_delta;
     bn->data_buffer.clone(&orig_bn->data_buffer);
     return bn;
 }
@@ -1007,7 +1006,6 @@ BASEMENTNODE toku_create_empty_bn_no_buffer(void) {
     bn->seqinsert = 0;
     bn->stale_ancestor_messages_applied = false;
     bn->stat64_delta = ZEROSTATS;
-    bn->logical_rows_delta = 0;
     bn->data_buffer.init_zero();
     return bn;
 }
@@ -1432,6 +1430,7 @@ static FTNODE alloc_ftnode_for_deserialize(uint32_t fullhash, BLOCKNUM blocknum)
     node->fullhash = fullhash;
     node->blocknum = blocknum;
     node->dirty = 0;
+    node->logical_rows_delta = 0;
     node->bp = nullptr;
     node->oldest_referenced_xid_known = TXNID_NONE;
     return node; 


### PR DESCRIPTION
- Update and select only workload with no partial eviction and high eviction rate eventually drives logical rowcount down to 0.
- Logical row delta not properly being un-applied on full eviction of clean node
- Moved BN LRC up into Leaf Node for easier/proper counting at node level.
- Corrected node eviction logic to un-apply LRC changes made due to message application during query with no node dirtying.
- Minor code format cleanup of struct ftnode