### PR TITLE
The fix for bug lp:1657908.

### DIFF
--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -2975,8 +2975,10 @@ env_dbremove(DB_ENV * env, DB_TXN *txn, const char *fname, const char *dbname, u
     if (txn && r) {
         if (r == EMFILE || r == ENFILE)
             r = toku_ydb_do_error(env, r, "toku dbremove failed because open file limit reached\n");
-        else
+        else if (r != ENOENT)
             r = toku_ydb_do_error(env, r, "toku dbremove failed\n");
+        else
+            r = 0;
         goto exit;
     }
     if (txn) {


### PR DESCRIPTION
When some tokudb file is deleted and the file does not exist on the moment of
deletion don't treat it as error.