### PR TITLE
 [TDB-6] src/ydb.cc:2917 can_acquire_table_lock: Assertion `r == 0'     failed (errno=36) (r=36)

### DIFF
--- a/ft/txn/roll.cc
+++ b/ft/txn/roll.cc
@@ -203,7 +203,7 @@ int toku_rollback_frename(BYTESTRING old_iname,
     }
 
     if (toku_stat(new_iname_full.get(), &stat) == -1) {
-        if (ENOENT == errno)
+        if (ENOENT == errno || ENAMETOOLONG == errno)
             new_exist = false;
         else
             return 1;

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -3061,28 +3061,31 @@ env_dbremove_subdb(DB_ENV * env, DB_TXN * txn, const char *fname, const char *db
 // see if we can acquire a table lock for the given dname.
 // requires: write lock on dname in the directory. dictionary
 //          open, close, and begin checkpoint cannot occur.
-// returns: true if we could open, lock, and close a dictionary
-//          with the given dname, false otherwise.
-static bool
+// returns: zero if we could open, lock, and close a dictionary
+//          with the given dname, errno otherwise.
+static int
 can_acquire_table_lock(DB_ENV *env, DB_TXN *txn, const char *iname_in_env) {
     int r;
-    bool got_lock = false;
     DB *db;
 
     r = toku_db_create(&db, env, 0);
     assert_zero(r);
     r = toku_db_open_iname(db, txn, iname_in_env, 0, 0);
-    assert_zero(r);
-    r = toku_db_pre_acquire_table_lock(db, txn);
-    if (r == 0) {
-        got_lock = true;
-    } else {
-        got_lock = false;
+    if(r) {
+	if (r == ENAMETOOLONG)
+	    toku_ydb_do_error(env, r, "File name too long!\n");
+	goto exit;
     }
-    r = toku_db_close(db);
-    assert_zero(r);
-
-    return got_lock;
+    r = toku_db_pre_acquire_table_lock(db, txn);
+    if (r) {
+        r = DB_LOCK_NOTGRANTED;
+    }
+exit:
+    if(db) {
+        int r2 = toku_db_close(db);
+        assert_zero(r2);
+    }
+    return r;
 }
 
 static int
@@ -3295,8 +3298,8 @@ env_dbrename(DB_ENV *env, DB_TXN *txn, const char *fname, const char *dbname, co
             // otherwise, we're okay in marking this ft as remove on
             // commit. no new handles can open for this dictionary
             // because the txn has directory write locks on the dname
-            if (txn && !can_acquire_table_lock(env, txn, new_iname.get())) {
-                r = DB_LOCK_NOTGRANTED;
+            if (txn) {
+                r = can_acquire_table_lock(env, txn, new_iname.get());
             }
             // We don't do anything at the ft or cachetable layer for rename.
             // We just update entries in the environment's directory.


### PR DESCRIPTION
        1) Once dir_per_db is enabled, env_dbrename exposes a bug of long
        db/file name, which was hidden before.
        2) The fix is very straightfoward. Simply return the system error
        code to the upper level caller.
        3) A ctest is modified to examine the patch path. No new ctest is
        needed.

Jenkin link here: http://jenkins.percona.com/view/TokuDB/job/PerconaFT-param/77/
ubuntu-yakkety-64bit is failing for something irrelevant ... will investigate