### PR TITLE
Kill query blocked in lock tree

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,16 @@ project(TokuDB)
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
+# detect when we are being built as a subproject
+if (DEFINED MYSQL_PROJECT_NAME_DOCSTRING)
+  add_definitions( -DMYSQL_TOKUDB_ENGINE=1)
+  if ((CMAKE_BUILD_TYPE MATCHES "Debug") AND
+      (CMAKE_CXX_FLAGS_DEBUG MATCHES " -DENABLED_DEBUG_SYNC"))
+    include_directories(${CMAKE_SOURCE_DIR}/include)
+    include_directories(${CMAKE_SOURCE_DIR}/sql)
+  endif ()
+endif ()
+
 ## Versions of gcc >= 4.9.0 require special version of 'ar' and 'ranlib' for
 ## link-time optimizations to work properly.
 ##

--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -428,6 +428,7 @@ static void print_db_env_struct (void) {
                              "int (*dirtool_attach)(DB_ENV *, DB_TXN *, const char *, const char *)",
                              "int (*dirtool_detach)(DB_ENV *, DB_TXN *, const char *)",
                              "int (*dirtool_move)(DB_ENV *, DB_TXN *, const char *, const char *)",
+                             "void (*kill_waiter)(DB_ENV *, void *extra)",
                              NULL};
 
         sort_and_dump_fields("db_env", true, extra);
@@ -548,8 +549,8 @@ static void print_db_txn_struct (void) {
 	"int (*abort_with_progress)(DB_TXN*, TXN_PROGRESS_POLL_FUNCTION, void*)",
 	"int (*xa_prepare) (DB_TXN*, TOKU_XA_XID *, uint32_t flags)",
         "uint64_t (*id64) (DB_TXN*)",
-        "void (*set_client_id)(DB_TXN *, uint64_t client_id)",
-        "uint64_t (*get_client_id)(DB_TXN *)",
+        "void (*set_client_id)(DB_TXN *, uint64_t client_id, void *client_extra)",
+        "void (*get_client_id)(DB_TXN *, uint64_t *client_id, void **client_extra)",
         "bool (*is_prepared)(DB_TXN *)",
         "DB_TXN *(*get_child)(DB_TXN *)",
         "uint64_t (*get_start_time)(DB_TXN *)",

--- a/buildheader/make_tdb.cc
+++ b/buildheader/make_tdb.cc
@@ -425,6 +425,9 @@ static void print_db_env_struct (void) {
                              "bool (*set_dir_per_db)(DB_ENV *, bool new_val)",
                              "bool (*get_dir_per_db)(DB_ENV *)",
                              "const char *(*get_data_dir)(DB_ENV *env)",
+                             "int (*dirtool_attach)(DB_ENV *, DB_TXN *, const char *, const char *)",
+                             "int (*dirtool_detach)(DB_ENV *, DB_TXN *, const char *)",
+                             "int (*dirtool_move)(DB_ENV *, DB_TXN *, const char *, const char *)",
                              NULL};
 
         sort_and_dump_fields("db_env", true, extra);

--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -3900,25 +3900,34 @@ struct keyrange_compare_s {
 };
 
 // TODO: Remove me, I'm boring
-static int keyrange_compare(DBT const &kdbt, const struct keyrange_compare_s &s) {
+static int keyrange_compare(DBT const &kdbt,
+                            const struct keyrange_compare_s &s) {
     return s.ft->cmp(&kdbt, s.key);
 }
 
-static void
-keysrange_in_leaf_partition (FT_HANDLE ft_handle, FTNODE node,
-                             DBT* key_left, DBT* key_right,
-                             int left_child_number, int right_child_number, uint64_t estimated_num_rows,
-                             uint64_t *less, uint64_t* equal_left, uint64_t* middle,
-                             uint64_t* equal_right, uint64_t* greater, bool* single_basement_node)
+static void keysrange_in_leaf_partition(FT_HANDLE ft_handle,
+                                        FTNODE node,
+                                        DBT *key_left,
+                                        DBT *key_right,
+                                        int left_child_number,
+                                        int right_child_number,
+                                        uint64_t estimated_num_rows,
+                                        uint64_t *less,
+                                        uint64_t *equal_left,
+                                        uint64_t *middle,
+                                        uint64_t *equal_right,
+                                        uint64_t *greater,
+                                        bool *single_basement_node)
 // If the partition is in main memory then estimate the number
 // Treat key_left == NULL as negative infinity
 // Treat key_right == NULL as positive infinity
 {
-    paranoid_invariant(node->height == 0); // we are in a leaf
+    paranoid_invariant(node->height == 0);  // we are in a leaf
     paranoid_invariant(!(key_left == NULL && key_right != NULL));
     paranoid_invariant(left_child_number <= right_child_number);
     bool single_basement = left_child_number == right_child_number;
-    paranoid_invariant(!single_basement || (BP_STATE(node, left_child_number) == PT_AVAIL));
+    paranoid_invariant(!single_basement ||
+                       (BP_STATE(node, left_child_number) == PT_AVAIL));
     if (BP_STATE(node, left_child_number) == PT_AVAIL) {
         int r;
         // The partition is in main memory then get an exact count.
@@ -3926,29 +3935,35 @@ keysrange_in_leaf_partition (FT_HANDLE ft_handle, FTNODE node,
         BASEMENTNODE bn = BLB(node, left_child_number);
         uint32_t idx_left = 0;
         // if key_left is NULL then set r==-1 and idx==0.
-        r = key_left ? bn->data_buffer.find_zero<decltype(s_left), keyrange_compare>(s_left, nullptr, nullptr, nullptr, &idx_left) : -1;
+        r = key_left
+                ? bn->data_buffer.find_zero<decltype(s_left), keyrange_compare>(
+                      s_left, nullptr, nullptr, nullptr, &idx_left)
+                : -1;
         *less = idx_left;
-        *equal_left = (r==0) ? 1 : 0;
+        *equal_left = (r == 0) ? 1 : 0;
 
         uint32_t size = bn->data_buffer.num_klpairs();
         uint32_t idx_right = size;
         r = -1;
         if (single_basement && key_right) {
             struct keyrange_compare_s s_right = {ft_handle->ft, key_right};
-            r = bn->data_buffer.find_zero<decltype(s_right), keyrange_compare>(s_right, nullptr, nullptr, nullptr, &idx_right);
+            r = bn->data_buffer.find_zero<decltype(s_right), keyrange_compare>(
+                s_right, nullptr, nullptr, nullptr, &idx_right);
         }
         *middle = idx_right - idx_left - *equal_left;
-        *equal_right = (r==0) ? 1 : 0;
+        *equal_right = (r == 0) ? 1 : 0;
         *greater = size - idx_right - *equal_right;
     } else {
         paranoid_invariant(!single_basement);
         uint32_t idx_left = estimated_num_rows / 2;
         if (!key_left) {
-            //Both nullptr, assume key_left belongs before leftmost entry, key_right belongs after rightmost entry
+            // Both nullptr, assume key_left belongs before leftmost entry,
+            // key_right belongs after rightmost entry
             idx_left = 0;
             paranoid_invariant(!key_right);
         }
-        // Assume idx_left and idx_right point to where key_left and key_right belong, (but are not there).
+        // Assume idx_left and idx_right point to where key_left and key_right
+        // belong, (but are not there).
         *less = idx_left;
         *equal_left = 0;
         *middle = estimated_num_rows - idx_left;
@@ -3958,44 +3973,76 @@ keysrange_in_leaf_partition (FT_HANDLE ft_handle, FTNODE node,
     *single_basement_node = single_basement;
 }
 
-static int
-toku_ft_keysrange_internal (FT_HANDLE ft_handle, FTNODE node,
-                            DBT* key_left, DBT* key_right, bool may_find_right,
-                            uint64_t* less, uint64_t* equal_left, uint64_t* middle,
-                            uint64_t* equal_right, uint64_t* greater, bool* single_basement_node,
-                            uint64_t estimated_num_rows,
-                            ftnode_fetch_extra *min_bfe, // set up to read a minimal read.
-                            ftnode_fetch_extra *match_bfe, // set up to read a basement node iff both keys in it
-                            struct unlockers *unlockers, ANCESTORS ancestors, const pivot_bounds &bounds)
-// Implementation note: Assign values to less, equal, and greater, and then on the way out (returning up the stack) we add more values in.
+static int toku_ft_keysrange_internal(
+    FT_HANDLE ft_handle,
+    FTNODE node,
+    DBT *key_left,
+    DBT *key_right,
+    bool may_find_right,
+    uint64_t *less,
+    uint64_t *equal_left,
+    uint64_t *middle,
+    uint64_t *equal_right,
+    uint64_t *greater,
+    bool *single_basement_node,
+    uint64_t estimated_num_rows,
+    ftnode_fetch_extra *min_bfe,  // set up to read a minimal read.
+    ftnode_fetch_extra
+        *match_bfe,  // set up to read a basement node iff both keys in it
+    struct unlockers *unlockers,
+    ANCESTORS ancestors,
+    const pivot_bounds &bounds)
+// Implementation note: Assign values to less, equal, and greater, and then on
+// the way out (returning up the stack) we add more values in.
 {
     int r = 0;
     // if KEY is NULL then use the leftmost key.
-    int left_child_number = key_left ? toku_ftnode_which_child (node, key_left, ft_handle->ft->cmp) : 0;
-    int right_child_number = node->n_children;  // Sentinel that does not equal left_child_number.
+    int left_child_number =
+        key_left ? toku_ftnode_which_child(node, key_left, ft_handle->ft->cmp)
+                 : 0;
+    int right_child_number =
+        node->n_children;  // Sentinel that does not equal left_child_number.
     if (may_find_right) {
-        right_child_number = key_right ? toku_ftnode_which_child (node, key_right, ft_handle->ft->cmp) : node->n_children - 1;
+        right_child_number =
+            key_right
+                ? toku_ftnode_which_child(node, key_right, ft_handle->ft->cmp)
+                : node->n_children - 1;
     }
 
     uint64_t rows_per_child = estimated_num_rows / node->n_children;
     if (node->height == 0) {
-        keysrange_in_leaf_partition(ft_handle, node, key_left, key_right, left_child_number, right_child_number,
-                                    rows_per_child, less, equal_left, middle, equal_right, greater, single_basement_node);
+        keysrange_in_leaf_partition(ft_handle,
+                                    node,
+                                    key_left,
+                                    key_right,
+                                    left_child_number,
+                                    right_child_number,
+                                    rows_per_child,
+                                    less,
+                                    equal_left,
+                                    middle,
+                                    equal_right,
+                                    greater,
+                                    single_basement_node);
 
-        *less    += rows_per_child * left_child_number;
+        *less += rows_per_child * left_child_number;
         if (*single_basement_node) {
-            *greater += rows_per_child * (node->n_children - left_child_number - 1);
+            *greater +=
+                rows_per_child * (node->n_children - left_child_number - 1);
         } else {
-            *middle += rows_per_child * (node->n_children - left_child_number - 1);
+            *middle +=
+                rows_per_child * (node->n_children - left_child_number - 1);
         }
     } else {
         // do the child.
         struct ancestors next_ancestors = {node, left_child_number, ancestors};
         BLOCKNUM childblocknum = BP_BLOCKNUM(node, left_child_number);
-        uint32_t fullhash = compute_child_fullhash(ft_handle->ft->cf, node, left_child_number);
+        uint32_t fullhash =
+            compute_child_fullhash(ft_handle->ft->cf, node, left_child_number);
         FTNODE childnode;
         bool msgs_applied = false;
-        bool child_may_find_right = may_find_right && left_child_number == right_child_number;
+        bool child_may_find_right =
+            may_find_right && left_child_number == right_child_number;
         r = toku_pin_ftnode_for_query(
             ft_handle,
             childblocknum,
@@ -4006,27 +4053,45 @@ toku_ft_keysrange_internal (FT_HANDLE ft_handle, FTNODE node,
             child_may_find_right ? match_bfe : min_bfe,
             false,
             &childnode,
-            &msgs_applied
-            );
+            &msgs_applied);
         paranoid_invariant(!msgs_applied);
         if (r != TOKUDB_TRY_AGAIN) {
             assert_zero(r);
 
-            struct unlock_ftnode_extra unlock_extra   = {ft_handle,childnode,false};
-            struct unlockers next_unlockers = {true, unlock_ftnode_fun, (void*)&unlock_extra, unlockers};
-            const pivot_bounds next_bounds = bounds.next_bounds(node, left_child_number);
+            struct unlock_ftnode_extra unlock_extra = {
+                ft_handle, childnode, false};
+            struct unlockers next_unlockers = {
+                true, unlock_ftnode_fun, (void *)&unlock_extra, unlockers};
+            const pivot_bounds next_bounds =
+                bounds.next_bounds(node, left_child_number);
 
-            r = toku_ft_keysrange_internal(ft_handle, childnode, key_left, key_right, child_may_find_right,
-                                           less, equal_left, middle, equal_right, greater, single_basement_node,
-                                           rows_per_child, min_bfe, match_bfe, &next_unlockers, &next_ancestors, next_bounds);
+            r = toku_ft_keysrange_internal(ft_handle,
+                                           childnode,
+                                           key_left,
+                                           key_right,
+                                           child_may_find_right,
+                                           less,
+                                           equal_left,
+                                           middle,
+                                           equal_right,
+                                           greater,
+                                           single_basement_node,
+                                           rows_per_child,
+                                           min_bfe,
+                                           match_bfe,
+                                           &next_unlockers,
+                                           &next_ancestors,
+                                           next_bounds);
             if (r != TOKUDB_TRY_AGAIN) {
                 assert_zero(r);
 
-                *less    += rows_per_child * left_child_number;
+                *less += rows_per_child * left_child_number;
                 if (*single_basement_node) {
-                    *greater += rows_per_child * (node->n_children - left_child_number - 1);
+                    *greater += rows_per_child *
+                                (node->n_children - left_child_number - 1);
                 } else {
-                    *middle += rows_per_child * (node->n_children - left_child_number - 1);
+                    *middle += rows_per_child *
+                               (node->n_children - left_child_number - 1);
                 }
 
                 assert(unlockers->locked);
@@ -4037,10 +4102,21 @@ toku_ft_keysrange_internal (FT_HANDLE ft_handle, FTNODE node,
     return r;
 }
 
-void toku_ft_keysrange(FT_HANDLE ft_handle, DBT* key_left, DBT* key_right, uint64_t *less_p, uint64_t* equal_left_p, uint64_t* middle_p, uint64_t* equal_right_p, uint64_t* greater_p, bool* middle_3_exact_p)
-// Effect: Return an estimate  of the number of keys to the left, the number equal (to left key), number between keys, number equal to right key, and the number to the right of both keys.
+void toku_ft_keysrange(FT_HANDLE ft_handle,
+                       DBT *key_left,
+                       DBT *key_right,
+                       uint64_t *less_p,
+                       uint64_t *equal_left_p,
+                       uint64_t *middle_p,
+                       uint64_t *equal_right_p,
+                       uint64_t *greater_p,
+                       bool *middle_3_exact_p)
+// Effect: Return an estimate  of the number of keys to the left, the number
+// equal (to left key), number between keys, number equal to right key, and the
+// number to the right of both keys.
 //   The values are an estimate.
-//   If you perform a keyrange on two keys that are in the same basement, equal_less, middle, and equal_right will be exact.
+//   If you perform a keyrange on two keys that are in the same basement,
+//   equal_less, middle, and equal_right will be exact.
 //   4184: What to do with a NULL key?
 //   key_left==NULL is treated as -infinity
 //   key_right==NULL is treated as +infinity
@@ -4048,10 +4124,21 @@ void toku_ft_keysrange(FT_HANDLE ft_handle, DBT* key_left, DBT* key_right, uint6
 //   key_right can be non-null only if key_left is non-null;
 {
     if (!key_left && key_right) {
-        // Simplify internals by only supporting key_right != null when key_left != null
-        // If key_right != null and key_left == null, then swap them and fix up numbers.
-        uint64_t less = 0, equal_left = 0, middle = 0, equal_right = 0, greater = 0;
-        toku_ft_keysrange(ft_handle, key_right, nullptr, &less, &equal_left, &middle, &equal_right, &greater, middle_3_exact_p);
+        // Simplify internals by only supporting key_right != null when key_left
+        // != null
+        // If key_right != null and key_left == null, then swap them and fix up
+        // numbers.
+        uint64_t less = 0, equal_left = 0, middle = 0, equal_right = 0,
+                 greater = 0;
+        toku_ft_keysrange(ft_handle,
+                          key_right,
+                          nullptr,
+                          &less,
+                          &equal_left,
+                          &middle,
+                          &equal_right,
+                          &greater,
+                          middle_3_exact_p);
         *less_p = 0;
         *equal_left_p = 0;
         *middle_p = less;
@@ -4064,98 +4151,132 @@ void toku_ft_keysrange(FT_HANDLE ft_handle, DBT* key_left, DBT* key_right, uint6
     paranoid_invariant(!(!key_left && key_right));
     ftnode_fetch_extra min_bfe;
     ftnode_fetch_extra match_bfe;
-    min_bfe.create_for_min_read(ft_handle->ft); // read pivot keys but not message buffers
-    match_bfe.create_for_keymatch(ft_handle->ft, key_left, key_right, false, false); // read basement node only if both keys in it.
-try_again:
+    min_bfe.create_for_min_read(
+        ft_handle->ft);  // read pivot keys but not message buffers
+    match_bfe.create_for_keymatch(
+        ft_handle->ft,
+        key_left,
+        key_right,
+        false,
+        false);  // read basement node only if both keys in it.
+try_again : {
+    uint64_t less = 0, equal_left = 0, middle = 0, equal_right = 0, greater = 0;
+    bool single_basement_node = false;
+    FTNODE node = NULL;
     {
-        uint64_t less = 0, equal_left = 0, middle = 0, equal_right = 0, greater = 0;
-        bool single_basement_node = false;
-        FTNODE node = NULL;
-        {
-            uint32_t fullhash;
-            CACHEKEY root_key;
-            toku_calculate_root_offset_pointer(ft_handle->ft, &root_key, &fullhash);
-            toku_pin_ftnode(
-                ft_handle->ft,
-                root_key,
-                fullhash,
-                &match_bfe,
-                PL_READ, // may_modify_node, cannot change root during keyrange
-                &node,
-                true
-                );
+        uint32_t fullhash;
+        CACHEKEY root_key;
+        toku_calculate_root_offset_pointer(ft_handle->ft, &root_key, &fullhash);
+        toku_pin_ftnode(
+            ft_handle->ft,
+            root_key,
+            fullhash,
+            &match_bfe,
+            PL_READ,  // may_modify_node, cannot change root during keyrange
+            &node,
+            true);
+    }
+
+    struct unlock_ftnode_extra unlock_extra = {ft_handle, node, false};
+    struct unlockers unlockers = {
+        true, unlock_ftnode_fun, (void *)&unlock_extra, (UNLOCKERS)NULL};
+
+    {
+        int r;
+        int64_t numrows = ft_handle->ft->in_memory_logical_rows;
+        if (numrows < 0)
+            numrows = 0;  // prevent appearance of a negative number
+        r = toku_ft_keysrange_internal(ft_handle,
+                                       node,
+                                       key_left,
+                                       key_right,
+                                       true,
+                                       &less,
+                                       &equal_left,
+                                       &middle,
+                                       &equal_right,
+                                       &greater,
+                                       &single_basement_node,
+                                       numrows,
+                                       &min_bfe,
+                                       &match_bfe,
+                                       &unlockers,
+                                       (ANCESTORS)NULL,
+                                       pivot_bounds::infinite_bounds());
+        assert(r == 0 || r == TOKUDB_TRY_AGAIN);
+        if (r == TOKUDB_TRY_AGAIN) {
+            assert(!unlockers.locked);
+            goto try_again;
         }
-
-        struct unlock_ftnode_extra unlock_extra = {ft_handle,node,false};
-        struct unlockers unlockers = {true, unlock_ftnode_fun, (void*)&unlock_extra, (UNLOCKERS)NULL};
-
-        {
-            int r;
-            int64_t numrows = ft_handle->ft->in_memory_stats.numrows;
-            if (numrows < 0)
-                numrows = 0;  // prevent appearance of a negative number
-            r = toku_ft_keysrange_internal (ft_handle, node, key_left, key_right, true,
-                                            &less, &equal_left, &middle, &equal_right, &greater,
-                                            &single_basement_node, numrows,
-                                            &min_bfe, &match_bfe, &unlockers, (ANCESTORS)NULL, pivot_bounds::infinite_bounds());
+        // May need to do a second query.
+        if (!single_basement_node && key_right != nullptr) {
+            // "greater" is stored in "middle"
+            invariant_zero(equal_right);
+            invariant_zero(greater);
+            uint64_t less2 = 0, equal_left2 = 0, middle2 = 0, equal_right2 = 0,
+                     greater2 = 0;
+            bool ignore;
+            r = toku_ft_keysrange_internal(ft_handle,
+                                           node,
+                                           key_right,
+                                           nullptr,
+                                           false,
+                                           &less2,
+                                           &equal_left2,
+                                           &middle2,
+                                           &equal_right2,
+                                           &greater2,
+                                           &ignore,
+                                           numrows,
+                                           &min_bfe,
+                                           &match_bfe,
+                                           &unlockers,
+                                           (ANCESTORS) nullptr,
+                                           pivot_bounds::infinite_bounds());
             assert(r == 0 || r == TOKUDB_TRY_AGAIN);
             if (r == TOKUDB_TRY_AGAIN) {
                 assert(!unlockers.locked);
                 goto try_again;
             }
-            // May need to do a second query.
-            if (!single_basement_node && key_right != nullptr) {
-                // "greater" is stored in "middle"
-                invariant_zero(equal_right);
-                invariant_zero(greater);
-                uint64_t less2 = 0, equal_left2 = 0, middle2 = 0, equal_right2 = 0, greater2 = 0;
-                bool ignore;
-                r = toku_ft_keysrange_internal (ft_handle, node, key_right, nullptr, false,
-                                                &less2, &equal_left2, &middle2, &equal_right2, &greater2,
-                                                &ignore, numrows,
-                                                &min_bfe, &match_bfe, &unlockers, (ANCESTORS)nullptr, pivot_bounds::infinite_bounds());
-                assert(r == 0 || r == TOKUDB_TRY_AGAIN);
-                if (r == TOKUDB_TRY_AGAIN) {
-                    assert(!unlockers.locked);
-                    goto try_again;
-                }
-                invariant_zero(equal_right2);
-                invariant_zero(greater2);
-                // Update numbers.
-                // less is already correct.
-                // equal_left is already correct.
+            invariant_zero(equal_right2);
+            invariant_zero(greater2);
+            // Update numbers.
+            // less is already correct.
+            // equal_left is already correct.
 
-                // "middle" currently holds everything greater than left_key in first query
-                // 'middle2' currently holds everything greater than right_key in second query
-                // 'equal_left2' is how many match right_key
+            // "middle" currently holds everything greater than left_key in
+            // first query
+            // 'middle2' currently holds everything greater than right_key in
+            // second query
+            // 'equal_left2' is how many match right_key
 
-                // Prevent underflow.
-                if (middle >= equal_left2 + middle2) {
-                    middle -= equal_left2 + middle2;
-                } else {
-                    middle = 0;
-                }
-                equal_right = equal_left2;
-                greater = middle2;
+            // Prevent underflow.
+            if (middle >= equal_left2 + middle2) {
+                middle -= equal_left2 + middle2;
+            } else {
+                middle = 0;
             }
+            equal_right = equal_left2;
+            greater = middle2;
         }
-        assert(unlockers.locked);
-        toku_unpin_ftnode_read_only(ft_handle->ft, node);
-        if (!key_right) {
-            paranoid_invariant_zero(equal_right);
-            paranoid_invariant_zero(greater);
-        }
-        if (!key_left) {
-            paranoid_invariant_zero(less);
-            paranoid_invariant_zero(equal_left);
-        }
-        *less_p        = less;
-        *equal_left_p  = equal_left;
-        *middle_p      = middle;
-        *equal_right_p = equal_right;
-        *greater_p     = greater;
-        *middle_3_exact_p = single_basement_node;
     }
+    assert(unlockers.locked);
+    toku_unpin_ftnode_read_only(ft_handle->ft, node);
+    if (!key_right) {
+        paranoid_invariant_zero(equal_right);
+        paranoid_invariant_zero(greater);
+    }
+    if (!key_left) {
+        paranoid_invariant_zero(less);
+        paranoid_invariant_zero(equal_left);
+    }
+    *less_p = less;
+    *equal_left_p = equal_left;
+    *middle_p = middle;
+    *equal_right_p = equal_right;
+    *greater_p = greater;
+    *middle_3_exact_p = single_basement_node;
+}
 }
 
 struct get_key_after_bytes_iterate_extra {

--- a/ft/txn/txn.cc
+++ b/ft/txn/txn.cc
@@ -269,6 +269,7 @@ static txn_child_manager tcm;
         .state = TOKUTXN_LIVE,
         .num_pin = 0,
         .client_id = 0,
+        .client_extra = nullptr,
         .start_time = time(NULL),
     };
 
@@ -705,12 +706,14 @@ bool toku_txn_has_spilled_rollback(TOKUTXN txn) {
     return txn_has_spilled_rollback_logs(txn);
 }
 
-uint64_t toku_txn_get_client_id(TOKUTXN txn) {
-    return txn->client_id;
+void toku_txn_get_client_id(TOKUTXN txn, uint64_t *client_id, void **client_extra) {
+    if (client_id) *client_id = txn->client_id;
+    if (client_extra) *client_extra = txn->client_extra;
 }
 
-void toku_txn_set_client_id(TOKUTXN txn, uint64_t client_id) {
+void toku_txn_set_client_id(TOKUTXN txn, uint64_t client_id, void *client_extra) {
     txn->client_id = client_id;
+    txn->client_extra = client_extra;
 }
 
 time_t toku_txn_get_start_time(struct tokutxn *txn) {

--- a/ft/txn/txn.h
+++ b/ft/txn/txn.h
@@ -193,6 +193,7 @@ struct tokutxn {
     uint32_t num_pin; // number of threads (all hot indexes) that want this
                       // txn to not transition to commit or abort
     uint64_t client_id;
+    void *client_extra;
     time_t start_time;
 };
 typedef struct tokutxn *TOKUTXN;
@@ -293,8 +294,8 @@ void toku_txn_unpin_live_txn(struct tokutxn *txn);
 
 bool toku_txn_has_spilled_rollback(struct tokutxn *txn);
 
-uint64_t toku_txn_get_client_id(struct tokutxn *txn);
-void toku_txn_set_client_id(struct tokutxn *txn, uint64_t client_id);
+void toku_txn_get_client_id(struct tokutxn *txn, uint64_t *client_id, void **client_extra);
+void toku_txn_set_client_id(struct tokutxn *txn, uint64_t client_id, void *client_extra);
 
 time_t toku_txn_get_start_time(struct tokutxn *txn);
 

--- a/locktree/lock_request.h
+++ b/locktree/lock_request.h
@@ -78,7 +78,7 @@ public:
 
     // effect: Resets the lock request parameters, allowing it to be reused.
     // requires: Lock request was already created at some point
-    void set(locktree *lt, TXNID txnid, const DBT *left_key, const DBT *right_key, type lock_type, bool big_txn);
+    void set(locktree *lt, TXNID txnid, const DBT *left_key, const DBT *right_key, type lock_type, bool big_txn, void *extra = nullptr);
 
     // effect: Tries to acquire a lock described by this lock request.
     // returns: The return code of locktree::acquire_[write,read]_lock()
@@ -110,11 +110,18 @@ public:
     //         Any lock requests successfully restarted is completed and woken up.
     //         The rest remain pending.
     static void retry_all_lock_requests(locktree *lt);
+    static void retry_all_lock_requests_info(lt_lock_request_info *info);
 
     void set_start_test_callback(void (*f)(void));
+    void set_start_before_pending_test_callback(void (*f)(void));
     void set_retry_test_callback(void (*f)(void));
-private:
 
+    void *get_extra(void) const;
+
+    void kill_waiter(void);
+    static void kill_waiter(locktree *lt, void *extra);
+
+private:
     enum state {
         UNINITIALIZED,
         INITIALIZED,
@@ -151,6 +158,8 @@ private:
     // the lock request info state stored in the
     // locktree that this lock request is for.
     struct lt_lock_request_info *m_info;
+
+    void *m_extra;
 
     // effect: tries again to acquire the lock described by this lock request
     // returns: 0 if retrying the request succeeded and is now complete

--- a/locktree/locktree.h
+++ b/locktree/locktree.h
@@ -159,6 +159,8 @@ namespace toku {
         // Add time t to the escalator's wait time statistics
         void add_escalator_wait_time(uint64_t t);
 
+        void kill_waiter(void *extra);
+
     private:
         static const uint64_t DEFAULT_MAX_LOCK_MEMORY = 64L * 1024 * 1024;
 

--- a/locktree/manager.cc
+++ b/locktree/manager.cc
@@ -483,4 +483,17 @@ void locktree_manager::get_status(LTM_STATUS statp) {
     *statp = ltm_status;
 }
 
+void locktree_manager::kill_waiter(void *extra) {
+    mutex_lock();
+    int r = 0;
+    size_t num_locktrees = m_locktree_map.size();
+    for (size_t i = 0; i < num_locktrees; i++) {
+        locktree *lt;
+        r = m_locktree_map.fetch(i, &lt);
+        invariant_zero(r);
+        lock_request::kill_waiter(lt, extra);
+    }
+    mutex_unlock();
+}
+
 } /* namespace toku */

--- a/locktree/tests/kill_waiter.cc
+++ b/locktree/tests/kill_waiter.cc
@@ -1,0 +1,100 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+
+// test the lock manager kill waiter function
+
+#include "locktree.h"
+#include "lock_request.h"
+#include "test.h"
+#include "locktree_unit_test.h"
+#include <thread>
+#include <atomic>
+
+namespace toku {
+
+const uint64_t my_lock_wait_time = 1000 * 1000;
+const uint64_t my_killed_time = 500 * 1000;
+const int n_locks = 4;
+
+static int my_killed_callback(void) {
+    if (1) fprintf(stderr, "%s:%u %s\n", __FILE__, __LINE__, __FUNCTION__);
+    return 0;
+}
+
+static void locktree_release_lock(locktree *lt, TXNID txn_id, const DBT *left, const DBT *right) {
+    range_buffer buffer;
+    buffer.create();
+    buffer.append(left, right);
+    lt->release_locks(txn_id, &buffer);
+    buffer.destroy();
+}
+
+static void wait_lock(lock_request *lr, std::atomic_int *done) {
+    int r = lr->wait(my_lock_wait_time, my_killed_time, my_killed_callback);
+    assert(r == DB_LOCK_NOTGRANTED);
+    *done = 1;
+}
+
+static void test_kill_waiter(void) {
+    int r;
+
+    locktree_manager mgr;
+    mgr.create(nullptr, nullptr, nullptr, nullptr);
+
+    DICTIONARY_ID dict_id = { 1 };
+    locktree *lt = mgr.get_lt(dict_id, dbt_comparator, nullptr);
+
+    const DBT *one = get_dbt(1);
+
+    lock_request locks[n_locks];
+    std::thread waiters[n_locks-1];
+    for (int i = 0; i < n_locks; i++) {
+        locks[i].create();
+        locks[i].set(lt, i+1, one, one, lock_request::type::WRITE, false, &waiters[i]);
+    }
+
+    // txn 'n_locks' grabs the lock
+    r = locks[n_locks-1].start();
+    assert_zero(r);
+
+    for (int i = 0; i < n_locks-1; i++) {
+        r = locks[i].start();
+        assert(r == DB_LOCK_NOTGRANTED);
+    }
+
+    std::atomic_int done[n_locks-1];
+    for (int i = 0; i < n_locks-1; i++) {
+        done[i] = 0;
+        waiters[i] = std::thread(wait_lock, &locks[i], &done[i]);
+    }
+
+    for (int i = 0; i < n_locks-1; i++) {
+        assert(!done[i]);
+    }
+
+    sleep(1);
+    for (int i = 0; i < n_locks-1; i++) {
+        mgr.kill_waiter(&waiters[i]);
+        while (!done[i]) sleep(1);
+        waiters[i].join();
+        for (int j = i+1; j < n_locks-1; j++)
+            assert(!done[j]);
+    }
+
+    locktree_release_lock(lt, n_locks, one, one);
+
+    for (int i = 0; i < n_locks; i++) {
+        locks[i].destroy();
+    }
+
+    mgr.release_lt(lt);
+    mgr.destroy();
+}
+
+} /* namespace toku */
+
+int main(void) {
+    toku::test_kill_waiter();
+    return 0;
+}
+

--- a/locktree/tests/lock_request_killed.cc
+++ b/locktree/tests/lock_request_killed.cc
@@ -51,8 +51,9 @@ static uint64_t t_do_kill;
 
 static int my_killed_callback(void) {
     uint64_t t_now = toku_current_time_microsec();
+    if (t_now == t_last_kill)
+        return 0;
     assert(t_now >= t_last_kill);
-    assert(t_now - t_last_kill >= my_killed_time * 1000 / 2); // div by 2 for valgrind which is not very accurate
     t_last_kill = t_now;
     killed_calls++;
     if (t_now >= t_do_kill)

--- a/locktree/tests/lock_request_not_killed.cc
+++ b/locktree/tests/lock_request_not_killed.cc
@@ -52,7 +52,6 @@ static uint64_t t_last_kill;
 static int my_killed_callback(void) {
     uint64_t t_now = toku_current_time_microsec();
     assert(t_now >= t_last_kill);
-    assert(t_now - t_last_kill >= my_killed_time * 1000 / 2); // div by 2 for valgrind which is not very accurate
     t_last_kill = t_now;
     killed_calls++;
     return 0;

--- a/portability/toku_debug_sync.h
+++ b/portability/toku_debug_sync.h
@@ -1,0 +1,78 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+This file is part of PerconaFT.
+
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+
+#pragma once
+
+struct tokutxn;
+
+#if defined(ENABLED_DEBUG_SYNC)
+
+/*
+  my_global.h which is included in m_string.h defines __STDC_FORMAT_MACROS,
+  the same macros is defined in TokuSetupCompiler.cmake, undefine it here
+  to avoid build errors
+*/
+#ifdef __STDC_FORMAT_MACROS
+#undef __STDC_FORMAT_MACROS
+#endif // __STDC_FORMAT_MACROS
+
+#include "m_string.h"
+#include "debug_sync.h"
+
+void toku_txn_get_client_id(struct tokutxn *txn,
+                            uint64_t *client_id,
+                            void **client_extra);
+
+inline void toku_debug_sync(struct tokutxn *txn, const char *sync_point_name) {
+    uint64_t client_id;
+    void *client_extra;
+    THD *thd;
+
+    if (likely(!opt_debug_sync_timeout))
+        return;
+
+    toku_txn_get_client_id(txn, &client_id, &client_extra);
+    thd = reinterpret_cast<THD *>(client_extra);
+    debug_sync(thd, sync_point_name, strlen(sync_point_name));
+}
+
+#else // defined(ENABLED_DEBUG_SYNC)
+
+inline void toku_debug_sync(struct tokutxn *, const char *) {};
+
+#endif // defined(ENABLED_DEBUG_SYNC)

--- a/portability/toku_portability.h
+++ b/portability/toku_portability.h
@@ -121,6 +121,7 @@ typedef int64_t toku_off_t;
 #include "toku_htod.h"
 #include "toku_assert.h"
 #include "toku_crash.h"
+#include "toku_debug_sync.h"
 
 #define UU(x) x __attribute__((__unused__))
 
@@ -183,8 +184,10 @@ extern void *realloc(void*, size_t)            __THROW __attribute__((__deprecat
 # pragma GCC poison u_int32_t
 # pragma GCC poison u_int64_t
 # pragma GCC poison BOOL
+#if !defined(MYSQL_TOKUDB_ENGINE)
 # pragma GCC poison FALSE
 # pragma GCC poison TRUE
+#endif // MYSQL_TOKUDB_ENGINE
 #endif
 #pragma GCC poison __sync_fetch_and_add
 #pragma GCC poison __sync_fetch_and_sub

--- a/src/tests/test_iterate_live_transactions.cc
+++ b/src/tests/test_iterate_live_transactions.cc
@@ -55,7 +55,8 @@ static int iterate_callback(DB_TXN *txn,
                             iterate_row_locks_callback iterate_locks,
                             void *locks_extra, void *extra) {
     uint64_t txnid = txn->id64(txn);
-    uint64_t client_id = txn->get_client_id(txn);
+    uint64_t client_id; void *client_extra;
+    txn->get_client_id(txn, &client_id, &client_extra);
     iterate_extra *info = reinterpret_cast<iterate_extra *>(extra);
     DB *db;
     DBT left_key, right_key;
@@ -93,13 +94,13 @@ int test_main(int UU(argc), char *const UU(argv[])) {
     r = env->open(env, TOKU_TEST_FILENAME, env_flags, 0755); CKERR(r);
 
     r = env->txn_begin(env, NULL, &txn1, 0); CKERR(r);
-    txn1->set_client_id(txn1, 0);
+    txn1->set_client_id(txn1, 0, nullptr);
     txnid1 = txn1->id64(txn1);
     r = env->txn_begin(env, NULL, &txn2, 0); CKERR(r);
-    txn2->set_client_id(txn2, 1);
+    txn2->set_client_id(txn2, 1, nullptr);
     txnid2 = txn2->id64(txn2);
     r = env->txn_begin(env, NULL, &txn3, 0); CKERR(r);
-    txn3->set_client_id(txn3, 2);
+    txn3->set_client_id(txn3, 2, nullptr);
     txnid3 = txn3->id64(txn3);
 
     {

--- a/src/tests/test_stress0.cc
+++ b/src/tests/test_stress0.cc
@@ -93,7 +93,8 @@ static int iterate_txns(DB_TXN *txn,
                         iterate_row_locks_callback iterate_locks,
                         void *locks_extra, void *extra) {
     uint64_t txnid = txn->id64(txn);
-    uint64_t client_id = txn->get_client_id(txn);
+    uint64_t client_id; void *client_extra;
+    txn->get_client_id(txn, &client_id, &client_extra);
     invariant_null(extra);
     invariant(txnid > 0);
     invariant(client_id == 0);

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -2775,6 +2775,10 @@ static void env_set_killed_callback(DB_ENV *env, uint64_t default_killed_time_ms
     env->i->killed_callback = killed_callback;
 }
 
+static void env_kill_waiter(DB_ENV *env, void *extra) {
+    env->i->ltm.kill_waiter(extra);
+}
+
 static void env_do_backtrace(DB_ENV *env) {
     if (env->i->errcall) {
         db_env_do_backtrace_errfunc((toku_env_err_func) toku_env_err, (const void *) env);
@@ -2877,6 +2881,7 @@ toku_env_create(DB_ENV ** envp, uint32_t flags) {
     USENV(set_dir_per_db);
     USENV(get_dir_per_db);
     USENV(get_data_dir);
+    USENV(kill_waiter);
 #undef USENV
     
     // unlocked methods

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -70,6 +70,8 @@ const char *toku_copyright_string = "Copyright (c) 2006, 2015, Percona and/or it
 #include "util/status.h"
 #include "util/context.h"
 
+#include <functional>
+
 // Include ydb_lib.cc here so that its constructor/destructor gets put into
 // ydb.o, to make sure they don't get erased at link time (when linking to
 // a static libtokufractaltree.a that was compiled with gcc).  See #5094.
@@ -1312,6 +1314,159 @@ static bool env_get_dir_per_db(DB_ENV *env) {
 
 static const char *env_get_data_dir(DB_ENV *env) {
     return env->i->real_data_dir;
+}
+
+static int env_dirtool_attach(DB_ENV *env,
+                              DB_TXN *txn,
+                              const char *dname,
+                              const char *iname) {
+    int r;
+    DBT dname_dbt;
+    DBT iname_dbt;
+
+    HANDLE_PANICKED_ENV(env);
+    if (!env_opened(env)) {
+        return EINVAL;
+    }
+    HANDLE_READ_ONLY_TXN(txn);
+    toku_fill_dbt(&dname_dbt, dname, strlen(dname) + 1);
+    toku_fill_dbt(&iname_dbt, iname, strlen(iname) + 1);
+
+    r = toku_db_put(env->i->directory,
+                    txn,
+                    &dname_dbt,
+                    &iname_dbt,
+                    0,
+                    true);
+        return r;
+}
+
+static int env_dirtool_detach(DB_ENV *env,
+                              DB_TXN *txn,
+                              const char *dname) {
+    int r;
+    DBT dname_dbt;
+    DBT old_iname_dbt;
+
+    HANDLE_PANICKED_ENV(env);
+    if (!env_opened(env)) {
+        return EINVAL;
+    }
+    HANDLE_READ_ONLY_TXN(txn);
+
+    toku_fill_dbt(&dname_dbt, dname, strlen(dname) + 1);
+    toku_init_dbt_flags(&old_iname_dbt, DB_DBT_REALLOC);
+
+    r = toku_db_get(env->i->directory,
+                    txn,
+                    &dname_dbt,
+                    &old_iname_dbt,
+                    DB_SERIALIZABLE);  // allocates memory for iname
+    if (r == DB_NOTFOUND)
+        return EEXIST;
+    toku_free(old_iname_dbt.data);
+
+    r = toku_db_del(env->i->directory, txn, &dname_dbt, DB_DELETE_ANY, true);
+
+    return r;
+}
+
+static int env_dirtool_move(DB_ENV *env,
+                            DB_TXN *txn,
+                            const char *old_dname,
+                            const char *new_dname) {
+    int r;
+    DBT old_dname_dbt;
+    DBT new_dname_dbt;
+    DBT iname_dbt;
+
+    HANDLE_PANICKED_ENV(env);
+    if (!env_opened(env)) {
+        return EINVAL;
+    }
+    HANDLE_READ_ONLY_TXN(txn);
+
+    toku_fill_dbt(&old_dname_dbt, old_dname, strlen(old_dname) + 1);
+    toku_fill_dbt(&new_dname_dbt, new_dname, strlen(new_dname) + 1);
+    toku_init_dbt_flags(&iname_dbt, DB_DBT_REALLOC);
+
+    r = toku_db_get(env->i->directory,
+                    txn,
+                    &old_dname_dbt,
+                    &iname_dbt,
+                    DB_SERIALIZABLE);  // allocates memory for iname
+    if (r == DB_NOTFOUND)
+        return EEXIST;
+
+    r = toku_db_del(
+        env->i->directory, txn, &old_dname_dbt, DB_DELETE_ANY, true);
+    if (r != 0)
+        goto exit;
+
+    r = toku_db_put(
+        env->i->directory, txn, &new_dname_dbt, &iname_dbt, 0, true);
+
+exit:
+    toku_free(iname_dbt.data);
+    return r;
+}
+
+static int locked_env_op(DB_ENV *env,
+                         DB_TXN *txn,
+                         std::function<int(DB_TXN *)> f) {
+    int ret, r;
+    HANDLE_READ_ONLY_TXN(txn);
+    HANDLE_ILLEGAL_WORKING_PARENT_TXN(env, txn);
+
+    DB_TXN *child_txn = NULL;
+    int using_txns = env->i->open_flags & DB_INIT_TXN;
+    if (using_txns) {
+        ret = toku_txn_begin(env, txn, &child_txn, 0);
+        lazy_assert_zero(ret);
+    }
+
+    // cannot begin a checkpoint
+    toku_multi_operation_client_lock();
+    r = f(child_txn);
+    toku_multi_operation_client_unlock();
+
+    if (using_txns) {
+        if (r == 0) {
+            ret = locked_txn_commit(child_txn, 0);
+            lazy_assert_zero(ret);
+        } else {
+            ret = locked_txn_abort(child_txn);
+            lazy_assert_zero(ret);
+        }
+    }
+    return r;
+
+}
+
+static int locked_env_dirtool_attach(DB_ENV *env,
+                                     DB_TXN *txn,
+                                     const char *dname,
+                                     const char *iname) {
+    auto f = std::bind(
+        env_dirtool_attach, env, std::placeholders::_1, dname, iname);
+    return locked_env_op(env, txn, f);
+}
+
+static int locked_env_dirtool_detach(DB_ENV *env,
+                                     DB_TXN *txn,
+                                     const char *dname) {
+    auto f = std::bind(
+        env_dirtool_detach, env, std::placeholders::_1, dname);
+    return locked_env_op(env, txn, f);
+}
+
+static int locked_env_dirtool_move(DB_ENV *env,
+                                   DB_TXN *txn,
+                                   const char *old_dname,
+                                   const char *new_dname) {
+    auto f = std::bind(
+        env_dirtool_move, env, std::placeholders::_1, old_dname, new_dname);
+    return locked_env_op(env, txn, f);
 }
 
 static int env_dbremove(DB_ENV * env, DB_TXN *txn, const char *fname, const char *dbname, uint32_t flags);
@@ -2646,6 +2801,9 @@ toku_env_create(DB_ENV ** envp, uint32_t flags) {
 #define SENV(name) result->name = locked_env_ ## name
     SENV(dbremove);
     SENV(dbrename);
+    SENV(dirtool_attach);
+    SENV(dirtool_detach);
+    SENV(dirtool_move);
     //SENV(set_noticecall);
 #undef SENV
 #define USENV(name) result->name = env_ ## name

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -2975,8 +2975,10 @@ env_dbremove(DB_ENV * env, DB_TXN *txn, const char *fname, const char *dbname, u
     if (txn && r) {
         if (r == EMFILE || r == ENFILE)
             r = toku_ydb_do_error(env, r, "toku dbremove failed because open file limit reached\n");
-        else
+        else if (r != ENOENT)
             r = toku_ydb_do_error(env, r, "toku dbremove failed\n");
+        else
+            r = 0;
         goto exit;
     }
     if (txn) {

--- a/src/ydb_row_lock.cc
+++ b/src/ydb_row_lock.cc
@@ -181,7 +181,16 @@ int toku_db_get_range_lock(DB *db, DB_TXN *txn, const DBT *left_key, const DBT *
     request.create();
     int r = toku_db_start_range_lock(db, txn, left_key, right_key, lock_type, &request);
     if (r == DB_LOCK_NOTGRANTED) {
+        toku_debug_sync(db_txn_struct_i(txn)->tokutxn,
+                        "toku_range_lock_before_wait");
         r = toku_db_wait_range_lock(db, txn, &request);
+        if (r == DB_LOCK_NOTGRANTED)
+            toku_debug_sync(db_txn_struct_i(txn)->tokutxn,
+                            "toku_range_lock_not_granted_after_wait");
+    }
+    else if (r == 0) {
+        toku_debug_sync(db_txn_struct_i(txn)->tokutxn,
+                        "toku_range_lock_granted_immediately");
     }
 
     request.destroy();

--- a/src/ydb_row_lock.cc
+++ b/src/ydb_row_lock.cc
@@ -191,9 +191,13 @@ int toku_db_get_range_lock(DB *db, DB_TXN *txn, const DBT *left_key, const DBT *
 // Setup and start an asynchronous lock request.
 int toku_db_start_range_lock(DB *db, DB_TXN *txn, const DBT *left_key, const DBT *right_key,
         toku::lock_request::type lock_type, toku::lock_request *request) {
+    uint64_t client_id;
+    void *client_extra;
     DB_TXN *txn_anc = txn_oldest_ancester(txn);
     TXNID txn_anc_id = txn_anc->id64(txn_anc);
-    request->set(db->i->lt, txn_anc_id, left_key, right_key, lock_type, toku_is_big_txn(txn_anc));
+    txn->get_client_id(txn, &client_id, &client_extra);
+    request->set(db->i->lt, txn_anc_id, left_key, right_key, lock_type,
+        toku_is_big_txn(txn_anc), client_extra);
 
     const int r = request->start();
     if (r == 0) {
@@ -241,6 +245,8 @@ int toku_db_get_point_write_lock(DB *db, DB_TXN *txn, const DBT *key) {
 // acquire a point write lock on the key for a given txn.
 // this does not block the calling thread.
 void toku_db_grab_write_lock (DB *db, DBT *key, TOKUTXN tokutxn) {
+    uint64_t client_id;
+    void *client_extra;
     DB_TXN *txn = toku_txn_get_container_db_txn(tokutxn);
     DB_TXN *txn_anc = txn_oldest_ancester(txn);
     TXNID txn_anc_id = txn_anc->id64(txn_anc);
@@ -248,7 +254,10 @@ void toku_db_grab_write_lock (DB *db, DBT *key, TOKUTXN tokutxn) {
     // This lock request must succeed, so we do not want to wait
     toku::lock_request request;
     request.create();
-    request.set(db->i->lt, txn_anc_id, key, key, toku::lock_request::type::WRITE, toku_is_big_txn(txn_anc));
+    txn->get_client_id(txn, &client_id, &client_extra);
+    request.set(db->i->lt, txn_anc_id, key, key,
+        toku::lock_request::type::WRITE, toku_is_big_txn(txn_anc),
+        client_extra);
     int r = request.start();
     invariant_zero(r);
     db_txn_note_row_lock(db, txn_anc, key, key);

--- a/src/ydb_txn.cc
+++ b/src/ydb_txn.cc
@@ -323,12 +323,12 @@ int locked_txn_abort(DB_TXN *txn) {
     return r;
 }
 
-static void locked_txn_set_client_id(DB_TXN *txn, uint64_t client_id) {
-    toku_txn_set_client_id(db_txn_struct_i(txn)->tokutxn, client_id);
+static void locked_txn_set_client_id(DB_TXN *txn, uint64_t client_id, void *client_extra) {
+    toku_txn_set_client_id(db_txn_struct_i(txn)->tokutxn, client_id, client_extra);
 }
 
-static uint64_t locked_txn_get_client_id(DB_TXN *txn) {
-    return toku_txn_get_client_id(db_txn_struct_i(txn)->tokutxn);
+static void locked_txn_get_client_id(DB_TXN *txn, uint64_t *client_id, void **client_extra) {
+    toku_txn_get_client_id(db_txn_struct_i(txn)->tokutxn, client_id, client_extra);
 }
 
 static int toku_txn_discard(DB_TXN *txn, uint32_t flags) {

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -6,6 +6,14 @@ foreach(tool ${tools})
   add_dependencies(${tool} install_tdb_h)
   target_link_libraries(${tool} ${LIBTOKUDB}_static ft_static z lzma snappy ${LIBTOKUPORTABILITY}_static ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
 
+  # detect when we are being built as a subproject
+  if (DEFINED MYSQL_PROJECT_NAME_DOCSTRING)
+    if ((CMAKE_BUILD_TYPE MATCHES "Debug") AND
+        (CMAKE_CXX_FLAGS_DEBUG MATCHES " -DENABLED_DEBUG_SYNC"))
+      target_link_libraries(${tool} sql binlog rpl master slave)
+    endif()
+  endif ()
+
   add_space_separated_property(TARGET ${tool} COMPILE_FLAGS -fvisibility=hidden)
 endforeach(tool)
 


### PR DESCRIPTION
TDB-27 : Add ability to kill query that is awaiting FT locktree lock
and
TDB-26 : Implement ability to use MySQL DEBUG_SYNC facility within PerconaFT

1) The ability to kill query blocked in lock-tree is added, see the initial pull request https://github.com/percona/PerconaFT/pull/360 .
2) The ability to use mysql debug_sync for mtr testing is added

See also:
https://github.com/percona/percona-server/pull/1738
https://github.com/percona/percona-server/pull/1739

MTR testing:
http://jenkins.percona.com/view/PS%205.6/job/percona-server-5.6-param/1896/
http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/934/