### PR TITLE
TDB-2 : row counts are being lost intermittently after restarts

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -651,8 +651,12 @@ void toku_ftnode_clone_callback(void *value_data,
     // set new pair attr if necessary
     if (node->height == 0) {
         *new_attr = make_ftnode_pair_attr(node);
-        node->logical_rows_delta = 0;
-        cloned_node->logical_rows_delta = 0;
+        for (int i = 0; i < node->n_children; i++) {
+            if (BP_STATE(node, i) == PT_AVAIL) {
+                BLB_LRD(node, i) = 0;
+                BLB_LRD(cloned_node, i) = 0;
+            }
+        }
     } else {
         new_attr->is_valid = false;
     }
@@ -700,9 +704,26 @@ void toku_ftnode_flush_callback(CACHEFILE UU(cachefile),
             if (ftnode->height == 0) {
                 FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF, 1);
                 FT_STATUS_INC(FT_FULL_EVICTIONS_LEAF_BYTES, node_size);
-                if (!ftnode->dirty) {
-                    toku_ft_adjust_logical_row_count(
-                        ft, -ftnode->logical_rows_delta);
+
+                // A leaf node (height == 0) is being evicted (!keep_me) and is
+                // not a checkpoint clone (!is_clone). This leaf node may have
+                // had messages applied to satisfy a query, but was never
+                // actually dirtied (!ftnode->dirty && !write_me). **Note that
+                // if (write_me) would persist the node and clear the dirty
+                // flag **. This message application may have updated the trees
+                // logical row count. Since these message applications are not
+                // persisted, we need undo the logical row count adjustments as
+                // they may occur again in the future if/when the node is
+                // re-read from disk for another query or change.
+                if (!ftnode->dirty && !write_me) {
+                    int64_t lrc_delta = 0;
+                    for (int i = 0; i < ftnode->n_children; i++) {
+                        if (BP_STATE(ftnode, i) == PT_AVAIL) {
+                            lrc_delta -= BLB_LRD(ftnode, i);
+                            BLB_LRD(ftnode, i) = 0;
+                        }
+                    }
+                    toku_ft_adjust_logical_row_count(ft, lrc_delta);
                 }
             } else {
                 FT_STATUS_INC(FT_FULL_EVICTIONS_NONLEAF, 1);
@@ -711,16 +732,17 @@ void toku_ftnode_flush_callback(CACHEFILE UU(cachefile),
             toku_free(*disk_data);
         } else {
             if (ftnode->height == 0) {
+                // No need to adjust logical row counts when flushing a clone
+                // as they should have been zeroed out anyway when cloned.
+                // Clones are 'copies' of work already done so doing it again
+                // (adjusting row counts) would be redundant and leads to
+                // inaccurate counts.
                 for (int i = 0; i < ftnode->n_children; i++) {
                     if (BP_STATE(ftnode, i) == PT_AVAIL) {
                         BASEMENTNODE bn = BLB(ftnode, i);
                         toku_ft_decrease_stats(&ft->in_memory_stats,
                                                bn->stat64_delta);
                     }
-                }
-                if (!ftnode->dirty) {
-                    toku_ft_adjust_logical_row_count(
-                        ft, -ftnode->logical_rows_delta);
                 }
             }
         }
@@ -947,6 +969,16 @@ int toku_ftnode_pe_callback(void *ftnode_pv,
                     basements_to_destroy[num_basements_to_destroy++] = bn;
                     toku_ft_decrease_stats(&ft->in_memory_stats,
                                            bn->stat64_delta);
+                    // A basement node is being partially evicted.
+                    // This masement node may have had messages applied to it to
+                    // satisfy a query, but was never actually dirtied.
+                    // This message application may have updated the trees
+                    // logical row count. Since these message applications are
+                    // not being persisted, we need undo the logical row count
+                    // adjustments as they may occur again in the future if/when
+                    // the node is re-read from disk for another query or change.
+                    toku_ft_adjust_logical_row_count(ft,
+                                                     -bn->logical_rows_delta);
                     set_BNULL(node, i);
                     BP_STATE(node, i) = PT_ON_DISK;
                     num_partial_evictions++;

--- a/ft/node.cc
+++ b/ft/node.cc
@@ -93,6 +93,7 @@ void toku_destroy_ftnode_internals(FTNODE node) {
             if (node->height > 0) {
                 destroy_nonleaf_childinfo(BNC(node,i));
             } else {
+                paranoid_invariant(BLB_LRD(node, i) == 0);
                 destroy_basement_node(BLB(node, i));
             }
         } else if (BP_STATE(node,i) == PT_COMPRESSED) {
@@ -386,8 +387,7 @@ static void bnc_apply_messages_to_basement_node(
     const pivot_bounds &
         bounds,  // contains pivot key bounds of this basement node
     txn_gc_info *gc_info,
-    bool *msgs_applied,
-    int64_t* logical_rows_delta) {
+    bool *msgs_applied) {
     int r;
     NONLEAF_CHILDINFO bnc = BNC(ancestor, childnum);
 
@@ -395,6 +395,7 @@ static void bnc_apply_messages_to_basement_node(
     // apply messages from this buffer
     STAT64INFO_S stats_delta = {0, 0};
     uint64_t workdone_this_ancestor = 0;
+    int64_t logical_rows_delta = 0;
 
     uint32_t stale_lbi, stale_ube;
     if (!bn->stale_ancestor_messages_applied) {
@@ -470,7 +471,7 @@ static void bnc_apply_messages_to_basement_node(
                             gc_info,
                             &workdone_this_ancestor,
                             &stats_delta,
-                            logical_rows_delta);
+                            &logical_rows_delta);
         }
     } else if (stale_lbi == stale_ube) {
         // No stale messages to apply, we just apply fresh messages, and mark
@@ -482,7 +483,7 @@ static void bnc_apply_messages_to_basement_node(
             .gc_info = gc_info,
             .workdone = &workdone_this_ancestor,
             .stats_to_update = &stats_delta,
-            .logical_rows_delta = logical_rows_delta};
+            .logical_rows_delta = &logical_rows_delta};
         if (fresh_ube - fresh_lbi > 0)
             *msgs_applied = true;
         r = bnc->fresh_message_tree
@@ -503,7 +504,7 @@ static void bnc_apply_messages_to_basement_node(
             .gc_info = gc_info,
             .workdone = &workdone_this_ancestor,
             .stats_to_update = &stats_delta,
-            .logical_rows_delta = logical_rows_delta};
+            .logical_rows_delta = &logical_rows_delta};
 
         r = bnc->stale_message_tree
                 .iterate_on_range<struct iterate_do_bn_apply_msg_extra,
@@ -521,6 +522,8 @@ static void bnc_apply_messages_to_basement_node(
     if (stats_delta.numbytes || stats_delta.numrows) {
         toku_ft_update_stats(&t->ft->in_memory_stats, stats_delta);
     }
+    toku_ft_adjust_logical_row_count(t->ft, logical_rows_delta);
+    bn->logical_rows_delta += logical_rows_delta;
 }
 
 static void
@@ -534,7 +537,6 @@ apply_ancestors_messages_to_bn(
     bool* msgs_applied
     )
 {
-    int64_t logical_rows_delta = 0;
     BASEMENTNODE curr_bn = BLB(node, childnum);
     const pivot_bounds curr_bounds = bounds.next_bounds(node, childnum);
     for (ANCESTORS curr_ancestors = ancestors; curr_ancestors; curr_ancestors = curr_ancestors->next) {
@@ -547,16 +549,13 @@ apply_ancestors_messages_to_bn(
                 curr_ancestors->childnum,
                 curr_bounds,
                 gc_info,
-                msgs_applied,
-                &logical_rows_delta
+                msgs_applied
                 );
             // We don't want to check this ancestor node again if the
             // next time we query it, the msn hasn't changed.
             curr_bn->max_msn_applied = curr_ancestors->node->max_msn_applied_to_node_on_disk;
         }
     }
-    toku_ft_adjust_logical_row_count(t->ft, logical_rows_delta);
-    node->logical_rows_delta += logical_rows_delta;
     // At this point, we know all the stale messages above this
     // basement node have been applied, and any new messages will be
     // fresh, so we don't need to look at stale messages for this

--- a/ft/node.h
+++ b/ft/node.h
@@ -175,11 +175,6 @@ struct ftnode {
     int height;
     int dirty;
     uint32_t fullhash;
-    // current count of rows add or removed as a result of message application
-    // to this node as a basement, irrelevant for internal nodes, gets reset
-    // when node is undirtied. Used to back out tree scoped LRC id node is
-    // evicted but not persisted
-    int64_t logical_rows_delta;
 
     // for internal nodes, if n_children==fanout+1 then the tree needs to be
     // rebalanced. for leaf nodes, represents number of basement nodes
@@ -211,6 +206,10 @@ struct ftnode_leaf_basement_node {
     unsigned int seqinsert;         // number of sequential inserts to this leaf 
     MSN max_msn_applied;            // max message sequence number applied
     bool stale_ancestor_messages_applied;
+    // current count of rows added or removed as a result of message application
+    // to this basement node, gets reset when node is undirtied.
+    // Used to back out tree scoped LRC id node is evicted but not persisted
+    int64_t logical_rows_delta;
     STAT64INFO_S stat64_delta;      // change in stat64 counters since basement was last written to disk
 };
 typedef struct ftnode_leaf_basement_node *BASEMENTNODE;
@@ -577,3 +576,4 @@ static inline void set_BSB(FTNODE node, int i, struct sub_block *sb) {
 #define BLB_DATA(node,i) (&(BLB(node,i)->data_buffer))
 #define BLB_NBYTESINDATA(node,i) (BLB_DATA(node,i)->get_disk_size())
 #define BLB_SEQINSERT(node,i) (BLB(node,i)->seqinsert)
+#define BLB_LRD(node, i) (BLB(node,i)->logical_rows_delta)


### PR DESCRIPTION
- Cleaned up access to BN logical_row_count_delta
- Moved lrc tracking back to individual basements and out of node itself due to
  need to track at the basement level for partial eviction.
- Fixed missing handling of row adjustment on partial eviction.
- Corrected logic in flush_callback to only adjust when exactly appropriate
  conditions.
- Corrected places to clear lrc adjustment counters when node gets written.