### PR TITLE
TDB-23  TDB-24

### DIFF
--- a/ft/cachetable/cachetable.cc
+++ b/ft/cachetable/cachetable.cc
@@ -464,7 +464,10 @@ int toku_cachetable_openf (CACHEFILE *cfptr, CACHETABLE ct, const char *fname_in
 
 char *
 toku_cachefile_fname_in_env (CACHEFILE cf) {
-    return cf->fname_in_env;
+    if (cf) {
+        return cf->fname_in_env;
+    }
+    return nullptr;
 }
 
 void toku_cachefile_set_fname_in_env(CACHEFILE cf, char *new_fname_in_env) {
@@ -2888,6 +2891,10 @@ void *toku_cachefile_get_userdata(CACHEFILE cf) {
 CACHETABLE
 toku_cachefile_get_cachetable(CACHEFILE cf) {
     return cf->cachetable;
+}
+
+CACHEFILE toku_pair_get_cachefile(PAIR pair) {
+    return pair->cachefile;
 }
 
 //Only called by ft_end_checkpoint

--- a/ft/cachetable/cachetable.h
+++ b/ft/cachetable/cachetable.h
@@ -297,6 +297,9 @@ void *toku_cachefile_get_userdata(CACHEFILE);
 CACHETABLE toku_cachefile_get_cachetable(CACHEFILE cf);
 // Effect: Get the cachetable.
 
+CACHEFILE toku_pair_get_cachefile(PAIR);
+// Effect: Get the cachefile of the pair
+
 void toku_cachetable_swap_pair_values(PAIR old_pair, PAIR new_pair);
 // Effect: Swaps the value_data of old_pair and new_pair. 
 // Requires: both old_pair and new_pair to be pinned with write locks.

--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -770,24 +770,48 @@ toku_ft_status_update_pivot_fetch_reason(ftnode_fetch_extra *bfe)
     }
 }
 
-int toku_ftnode_fetch_callback (CACHEFILE UU(cachefile), PAIR p, int fd, BLOCKNUM blocknum, uint32_t fullhash,
-                                 void **ftnode_pv,  void** disk_data, PAIR_ATTR *sizep, int *dirtyp, void *extraargs) {
+int toku_ftnode_fetch_callback(CACHEFILE UU(cachefile),
+                               PAIR p,
+                               int fd,
+                               BLOCKNUM blocknum,
+                               uint32_t fullhash,
+                               void **ftnode_pv,
+                               void **disk_data,
+                               PAIR_ATTR *sizep,
+                               int *dirtyp,
+                               void *extraargs) {
     assert(extraargs);
-    assert(*ftnode_pv == NULL);
-    FTNODE_DISK_DATA* ndd = (FTNODE_DISK_DATA*)disk_data;
+    assert(*ftnode_pv == nullptr);
+    FTNODE_DISK_DATA *ndd = (FTNODE_DISK_DATA *)disk_data;
     ftnode_fetch_extra *bfe = (ftnode_fetch_extra *)extraargs;
-    FTNODE *node=(FTNODE*)ftnode_pv;
+    FTNODE *node = (FTNODE *)ftnode_pv;
     // deserialize the node, must pass the bfe in because we cannot
     // evaluate what piece of the the node is necessary until we get it at
     // least partially into memory
-    int r = toku_deserialize_ftnode_from(fd, blocknum, fullhash, node, ndd, bfe);
+    int r =
+        toku_deserialize_ftnode_from(fd, blocknum, fullhash, node, ndd, bfe);
     if (r != 0) {
         if (r == TOKUDB_BAD_CHECKSUM) {
-            fprintf(stderr,
-                    "Checksum failure while reading node in file %s.\n",
-                    toku_cachefile_fname_in_env(cachefile));
+            fprintf(
+                stderr,
+                "%s:%d:toku_ftnode_fetch_callback - "
+                "file[%s], blocknum[%ld], toku_deserialize_ftnode_from "
+                "failed with a checksum error.\n",
+                __FILE__,
+                __LINE__,
+                toku_cachefile_fname_in_env(cachefile),
+                blocknum.b);
         } else {
-            fprintf(stderr, "Error deserializing node, errno = %d", r);
+            fprintf(
+                stderr,
+                "%s:%d:toku_ftnode_fetch_callback - "
+                "file[%s], blocknum[%ld], toku_deserialize_ftnode_from "
+                "failed with %d.\n",
+                __FILE__,
+                __LINE__,
+                toku_cachefile_fname_in_env(cachefile),
+                blocknum.b,
+                r);
         }
         // make absolutely sure we crash before doing anything else.
         abort();
@@ -796,7 +820,8 @@ int toku_ftnode_fetch_callback (CACHEFILE UU(cachefile), PAIR p, int fd, BLOCKNU
     if (r == 0) {
         *sizep = make_ftnode_pair_attr(*node);
         (*node)->ct_pair = p;
-        *dirtyp = (*node)->dirty;  // deserialize could mark the node as dirty (presumably for upgrade)
+        *dirtyp = (*node)->dirty;  // deserialize could mark the node as dirty
+                                   // (presumably for upgrade)
     }
     return r;
 }

--- a/ft/ft.cc
+++ b/ft/ft.cc
@@ -435,7 +435,8 @@ int toku_read_ft_and_store_in_cachefile (FT_HANDLE ft_handle, CACHEFILE cf, LSN 
     }
 
     int fd = toku_cachefile_get_fd(cf);
-    int r = toku_deserialize_ft_from(fd, max_acceptable_lsn, &ft);
+    const char *fn = toku_cachefile_fname_in_env(cf);
+    int r = toku_deserialize_ft_from(fd, fn, max_acceptable_lsn, &ft);
     if (r == TOKUDB_BAD_CHECKSUM) {
         fprintf(stderr, "Checksum failure while reading header in file %s.\n", toku_cachefile_fname_in_env(cf));
         assert(false);  // make absolutely sure we crash before doing anything else

--- a/ft/node.h
+++ b/ft/node.h
@@ -384,6 +384,16 @@ enum reactivity toku_ftnode_get_reactivity(FT ft, FTNODE node);
 enum reactivity toku_ftnode_get_nonleaf_reactivity(FTNODE node, unsigned int fanout);
 enum reactivity toku_ftnode_get_leaf_reactivity(FTNODE node, uint32_t nodesize);
 
+inline const char* toku_ftnode_get_cachefile_fname_in_env(FTNODE node) {
+    if (node->ct_pair) {
+        CACHEFILE cf = toku_pair_get_cachefile(node->ct_pair);
+        if (cf) {
+            return toku_cachefile_fname_in_env(cf);
+        }
+    }
+    return nullptr;
+}
+
 /**
  * Finds the next child for HOT to flush to, given that everything up to
  * and including k has been flattened.

--- a/ft/serialize/ft-serialize.h
+++ b/ft/serialize/ft-serialize.h
@@ -42,12 +42,23 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "ft/serialize/block_table.h"
 
 size_t toku_serialize_ft_size(struct ft_header *h);
-void toku_serialize_ft_to(int fd, struct ft_header *h, block_table *bt, CACHEFILE cf);
-void toku_serialize_ft_to_wbuf(struct wbuf *wbuf, struct ft_header *h, DISKOFF translation_location_on_disk, DISKOFF translation_size_on_disk);
-void toku_serialize_descriptor_contents_to_fd(int fd, DESCRIPTOR desc, DISKOFF offset);
-void toku_serialize_descriptor_contents_to_wbuf(struct wbuf *wb, DESCRIPTOR desc);
-
-int toku_deserialize_ft_from(int fd, LSN max_acceptable_lsn, FT *ft);
+void toku_serialize_ft_to(int fd,
+                          struct ft_header *h,
+                          block_table *bt,
+                          CACHEFILE cf);
+void toku_serialize_ft_to_wbuf(struct wbuf *wbuf,
+                               struct ft_header *h,
+                               DISKOFF translation_location_on_disk,
+                               DISKOFF translation_size_on_disk);
+void toku_serialize_descriptor_contents_to_fd(int fd,
+                                              DESCRIPTOR desc,
+                                              DISKOFF offset);
+void toku_serialize_descriptor_contents_to_wbuf(struct wbuf *wb,
+                                                DESCRIPTOR desc);
+int toku_deserialize_ft_from(int fd,
+                             const char *fn,
+                             LSN max_acceptable_lsn,
+                             FT *ft);
 
 // TODO rename
 int deserialize_ft_from_fd_into_rbuf(int fd,

--- a/ft/serialize/ft_node-serialize.cc
+++ b/ft/serialize/ft_node-serialize.cc
@@ -1158,15 +1158,25 @@ just_decompress_sub_block(struct sub_block *sb)
 }
 
 // verify the checksum
-int
-verify_ftnode_sub_block (struct sub_block *sb)
-{
+int verify_ftnode_sub_block(struct sub_block *sb,
+                            const char *fname,
+                            BLOCKNUM blocknum) {
     int r = 0;
     // first verify the checksum
     uint32_t data_size = sb->uncompressed_size - 4; // checksum is 4 bytes at end
     uint32_t stored_xsum = toku_dtoh32(*((uint32_t *)((char *)sb->uncompressed_ptr + data_size)));
     uint32_t actual_xsum = toku_x1764_memory(sb->uncompressed_ptr, data_size);
     if (stored_xsum != actual_xsum) {
+        fprintf(
+            stderr,
+            "%s:%d:verify_ftnode_sub_block - "
+            "file[%s], blocknum[%ld], stored_xsum[%u] != actual_xsum[%u]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            stored_xsum,
+            actual_xsum);
         dump_bad_block((Bytef *) sb->uncompressed_ptr, sb->uncompressed_size);
         r = TOKUDB_BAD_CHECKSUM;
     }
@@ -1174,19 +1184,27 @@ verify_ftnode_sub_block (struct sub_block *sb)
 }
 
 // This function deserializes the data stored by serialize_ftnode_info
-static int
-deserialize_ftnode_info(
-    struct sub_block *sb, 
-    FTNODE node
-    )
-{
+static int deserialize_ftnode_info(struct sub_block *sb, FTNODE node) {
+
     // sb_node_info->uncompressed_ptr stores the serialized node information
     // this function puts that information into node
 
     // first verify the checksum
     int r = 0;
-    r = verify_ftnode_sub_block(sb);
+    const char *fname = toku_ftnode_get_cachefile_fname_in_env(node);
+    r = verify_ftnode_sub_block(sb, fname, node->blocknum);
     if (r != 0) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_info - "
+            "file[%s], blocknum[%ld], verify_ftnode_sub_block failed with %d\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            node->blocknum.b,
+            r);
+        dump_bad_block(static_cast<unsigned char *>(sb->uncompressed_ptr),
+                       sb->uncompressed_size);
         goto exit;
     }
 
@@ -1232,6 +1250,16 @@ deserialize_ftnode_info(
 
     // make sure that all the data was read
     if (data_size != rb.ndone) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_info - "
+            "file[%s], blocknum[%ld], data_size[%d] != rb.ndone[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            node->blocknum.b,
+            data_size,
+            rb.ndone);
         dump_bad_block(rb.buf, rb.size);
         abort();
     }
@@ -1348,17 +1376,25 @@ static void setup_ftnode_partitions(FTNODE node, ftnode_fetch_extra *bfe, bool d
 /* deserialize the partition from the sub-block's uncompressed buffer
  * and destroy the uncompressed buffer
  */
-static int
-deserialize_ftnode_partition(
+static int deserialize_ftnode_partition(
     struct sub_block *sb,
     FTNODE node,
-    int childnum,      // which partition to deserialize
-    const toku::comparator &cmp
-    )
-{
+    int childnum,  // which partition to deserialize
+    const toku::comparator &cmp) {
+
     int r = 0;
-    r = verify_ftnode_sub_block(sb);
+    const char *fname = toku_ftnode_get_cachefile_fname_in_env(node);
+    r = verify_ftnode_sub_block(sb, fname, node->blocknum);
     if (r != 0) {
+        fprintf(stderr,
+                "%s:%d:deserialize_ftnode_partition - "
+                "file[%s], blocknum[%ld], "
+                "verify_ftnode_sub_block failed with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                node->blocknum.b,
+                r);
         goto exit;
     }
     uint32_t data_size;
@@ -1371,7 +1407,20 @@ deserialize_ftnode_partition(
     ch = rbuf_char(&rb);
 
     if (node->height > 0) {
-        assert(ch == FTNODE_PARTITION_MSG_BUFFER);
+        if (ch != FTNODE_PARTITION_MSG_BUFFER) {
+            fprintf(stderr,
+                    "%s:%d:deserialize_ftnode_partition - "
+                    "file[%s], blocknum[%ld], ch[%d] != "
+                    "FTNODE_PARTITION_MSG_BUFFER[%d]\n",
+                    __FILE__,
+                    __LINE__,
+                    fname ? fname : "unknown",
+                    node->blocknum.b,
+                    ch,
+                    FTNODE_PARTITION_MSG_BUFFER);
+            dump_bad_block(rb.buf, rb.size);
+            assert(ch == FTNODE_PARTITION_MSG_BUFFER);
+        }
         NONLEAF_CHILDINFO bnc = BNC(node, childnum);
         if (node->layout_version_read_from_disk <= FT_LAYOUT_VERSION_26) {
             // Layout version <= 26 did not serialize sorted message trees to disk.
@@ -1380,43 +1429,99 @@ deserialize_ftnode_partition(
             deserialize_child_buffer(bnc, &rb);
         }
         BP_WORKDONE(node, childnum) = 0;
-    }
-    else {
-        assert(ch == FTNODE_PARTITION_DMT_LEAVES);
+    } else {
+        if (ch != FTNODE_PARTITION_DMT_LEAVES) {
+            fprintf(stderr,
+                    "%s:%d:deserialize_ftnode_partition - "
+                    "file[%s], blocknum[%ld], ch[%d] != "
+                    "FTNODE_PARTITION_DMT_LEAVES[%d]\n",
+                    __FILE__,
+                    __LINE__,
+                    fname ? fname : "unknown",
+                    node->blocknum.b,
+                    ch,
+                    FTNODE_PARTITION_DMT_LEAVES);
+            dump_bad_block(rb.buf, rb.size);
+            assert(ch == FTNODE_PARTITION_DMT_LEAVES);
+        }
+
         BLB_SEQINSERT(node, childnum) = 0;
         uint32_t num_entries = rbuf_int(&rb);
         // we are now at the first byte of first leafentry
         data_size -= rb.ndone; // remaining bytes of leafentry data
 
         BASEMENTNODE bn = BLB(node, childnum);
-        bn->data_buffer.deserialize_from_rbuf(num_entries, &rb, data_size, node->layout_version_read_from_disk);
+        bn->data_buffer.deserialize_from_rbuf(
+            num_entries, &rb, data_size, node->layout_version_read_from_disk);
     }
-    assert(rb.ndone == rb.size);
+    if (rb.ndone != rb.size) {
+        fprintf(stderr,
+                "%s:%d:deserialize_ftnode_partition - "
+                "file[%s], blocknum[%ld], rb.ndone[%d] != rb.size[%d]\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                node->blocknum.b,
+                rb.ndone,
+                rb.size);
+        dump_bad_block(rb.buf, rb.size);
+        assert(rb.ndone == rb.size);
+    }
+
 exit:
     return r;
 }
 
-static int
-decompress_and_deserialize_worker(struct rbuf curr_rbuf, struct sub_block curr_sb, FTNODE node, int child,
-                                 const toku::comparator &cmp, tokutime_t *decompress_time)
-{
+static int decompress_and_deserialize_worker(struct rbuf curr_rbuf,
+                                             struct sub_block curr_sb,
+                                             FTNODE node,
+                                             int child,
+                                             const toku::comparator &cmp,
+                                             tokutime_t *decompress_time) {
     int r = 0;
     tokutime_t t0 = toku_time_now();
     r = read_and_decompress_sub_block(&curr_rbuf, &curr_sb);
-    tokutime_t t1 = toku_time_now();
-    if (r == 0) {
-        // at this point, sb->uncompressed_ptr stores the serialized node partition
-        r = deserialize_ftnode_partition(&curr_sb, node, child, cmp);
+    if (r != 0) {
+        const char *fname = toku_ftnode_get_cachefile_fname_in_env(node);
+        fprintf(stderr,
+                "%s:%d:decompress_and_deserialize_worker - "
+                "file[%s], blocknum[%ld], read_and_decompress_sub_block failed "
+                "with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                node->blocknum.b,
+                r);
+        dump_bad_block(curr_rbuf.buf, curr_rbuf.size);
+        goto exit;
     }
-    *decompress_time = t1 - t0;
+    *decompress_time = toku_time_now() - t0;
+    // at this point, sb->uncompressed_ptr stores the serialized node partition
+    r = deserialize_ftnode_partition(&curr_sb, node, child, cmp);
+    if (r != 0) {
+        const char *fname = toku_ftnode_get_cachefile_fname_in_env(node);
+        fprintf(stderr,
+                "%s:%d:decompress_and_deserialize_worker - "
+                "file[%s], blocknum[%ld], deserialize_ftnode_partition failed "
+                "with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                node->blocknum.b,
+                r);
+        dump_bad_block(curr_rbuf.buf, curr_rbuf.size);
+        goto exit;
+    }
 
+exit:
     toku_free(curr_sb.uncompressed_ptr);
     return r;
 }
 
-static int
-check_and_copy_compressed_sub_block_worker(struct rbuf curr_rbuf, struct sub_block curr_sb, FTNODE node, int child)
-{
+static int check_and_copy_compressed_sub_block_worker(struct rbuf curr_rbuf,
+                                                      struct sub_block curr_sb,
+                                                      FTNODE node,
+                                                      int child) {
     int r = 0;
     r = read_compressed_sub_block(&curr_rbuf, &curr_sb);
     if (r != 0) {
@@ -1428,7 +1533,8 @@ check_and_copy_compressed_sub_block_worker(struct rbuf curr_rbuf, struct sub_blo
     bp_sb->compressed_size = curr_sb.compressed_size;
     bp_sb->uncompressed_size = curr_sb.uncompressed_size;
     bp_sb->compressed_ptr = toku_xmalloc(bp_sb->compressed_size);
-    memcpy(bp_sb->compressed_ptr, curr_sb.compressed_ptr, bp_sb->compressed_size);
+    memcpy(
+        bp_sb->compressed_ptr, curr_sb.compressed_ptr, bp_sb->compressed_size);
 exit:
     return r;
 }
@@ -1439,34 +1545,50 @@ static FTNODE alloc_ftnode_for_deserialize(uint32_t fullhash, BLOCKNUM blocknum)
     node->fullhash = fullhash;
     node->blocknum = blocknum;
     node->dirty = 0;
-    node->bp = nullptr;
     node->oldest_referenced_xid_known = TXNID_NONE;
+    node->bp = nullptr;
+    node->ct_pair = nullptr;
     return node; 
 }
 
-static int
-deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
-                                                      FTNODE_DISK_DATA* ndd, 
-                                                      BLOCKNUM blocknum,
-                                                      uint32_t fullhash,
-                                                      ftnode_fetch_extra *bfe,
-                                                      struct rbuf *rb,
-                                                      int fd)
+static int deserialize_ftnode_header_from_rbuf_if_small_enough(
+    FTNODE *ftnode,
+    FTNODE_DISK_DATA *ndd,
+    BLOCKNUM blocknum,
+    uint32_t fullhash,
+    ftnode_fetch_extra *bfe,
+    struct rbuf *rb,
+    int fd)
 // If we have enough information in the rbuf to construct a header, then do so.
 // Also fetch in the basement node if needed.
-// Return 0 if it worked.  If something goes wrong (including that we are looking at some old data format that doesn't have partitions) then return nonzero.
+// Return 0 if it worked.  If something goes wrong (including that we are
+// looking at some old data format that doesn't have partitions) then return
+// nonzero.
 {
     int r = 0;
 
     tokutime_t t0, t1;
     tokutime_t decompress_time = 0;
     tokutime_t deserialize_time = 0;
+    // we must get the name from bfe and not through
+    // toku_ftnode_get_cachefile_fname_in_env as the node is not set up yet
+    const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
     
     t0 = toku_time_now();
 
     FTNODE node = alloc_ftnode_for_deserialize(fullhash, blocknum);
 
     if (rb->size < 24) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], rb->size[%u] < 24\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            rb->size);
+        dump_bad_block(rb->buf, rb->size);
         // TODO: What error do we return here?
         // Does it even matter?
         r = toku_db_badformat();
@@ -1475,14 +1597,45 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
 
     const void *magic;
     rbuf_literal_bytes(rb, &magic, 8);
-    if (memcmp(magic, "tokuleaf", 8)!=0 &&
-        memcmp(magic, "tokunode", 8)!=0) {
+    if (memcmp(magic, "tokuleaf", 8) != 0 &&
+        memcmp(magic, "tokunode", 8) != 0) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], unrecognized magic number "
+            "%2.2x %2.2x %2.2x %2.2x   %2.2x %2.2x %2.2x %2.2x\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            static_cast<const uint8_t*>(magic)[0],
+            static_cast<const uint8_t*>(magic)[1],
+            static_cast<const uint8_t*>(magic)[2],
+            static_cast<const uint8_t*>(magic)[3],
+            static_cast<const uint8_t*>(magic)[4],
+            static_cast<const uint8_t*>(magic)[5],
+            static_cast<const uint8_t*>(magic)[6],
+            static_cast<const uint8_t*>(magic)[7]);
+        dump_bad_block(rb->buf, rb->size);
         r = toku_db_badformat();        
         goto cleanup;
     }
 
     node->layout_version_read_from_disk = rbuf_int(rb);
-    if (node->layout_version_read_from_disk < FT_FIRST_LAYOUT_VERSION_WITH_BASEMENT_NODES) {
+    if (node->layout_version_read_from_disk <
+        FT_FIRST_LAYOUT_VERSION_WITH_BASEMENT_NODES) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], node->layout_version_read_from_disk[%d] "
+            "< FT_FIRST_LAYOUT_VERSION_WITH_BASEMENT_NODES[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            node->layout_version_read_from_disk,
+            FT_FIRST_LAYOUT_VERSION_WITH_BASEMENT_NODES);
+        dump_bad_block(rb->buf, rb->size);
         // This code path doesn't have to worry about upgrade.
         r = toku_db_badformat();
         goto cleanup;
@@ -1504,10 +1657,24 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
     // is too big, we may have a problem, so check that we won't overflow
     // while reading the partition locations.
     unsigned int nhsize;
-    nhsize =  serialize_node_header_size(node); // we can do this because n_children is filled in.
+    // we can do this because n_children is filled in.
+    nhsize = serialize_node_header_size(node);
     unsigned int needed_size;
-    needed_size = nhsize + 12; // we need 12 more so that we can read the compressed block size information that follows for the nodeinfo.
+    // we need 12 more so that we can read the compressed block size information
+    // that follows for the nodeinfo.
+    needed_size = nhsize + 12;
     if (needed_size > rb->size) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], needed_size[%d] > rb->size[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            needed_size,
+            rb->size);
+        dump_bad_block(rb->buf, rb->size);
         r = toku_db_badformat();
         goto cleanup;
     }
@@ -1525,6 +1692,16 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
     uint32_t stored_checksum;
     stored_checksum = rbuf_int(rb);
     if (stored_checksum != checksum) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], stored_checksum[%d] != checksum[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            stored_checksum,
+            checksum);
         dump_bad_block(rb->buf, rb->size);
         r = TOKUDB_BAD_CHECKSUM;
         goto cleanup;
@@ -1533,9 +1710,23 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
     // Now we want to read the pivot information.
     struct sub_block sb_node_info;
     sub_block_init(&sb_node_info);
-    sb_node_info.compressed_size = rbuf_int(rb); // we'll be able to read these because we checked the size earlier.
+    // we'll be able to read these because we checked the size earlier.
+    sb_node_info.compressed_size = rbuf_int(rb);
     sb_node_info.uncompressed_size = rbuf_int(rb);
-    if (rb->size-rb->ndone < sb_node_info.compressed_size + 8) {
+    if (rb->size - rb->ndone < sb_node_info.compressed_size + 8) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], rb->size[%d] - rb->ndone[%d] < "
+            "sb_node_info.compressed_size[%d] + 8\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            rb->size,
+            rb->ndone,
+            sb_node_info.compressed_size);
+        dump_bad_block(rb->buf, rb->size);
         r = toku_db_badformat();
         goto cleanup;
     }
@@ -1547,8 +1738,20 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
     sb_node_info.xsum = rbuf_int(rb);
     // let's check the checksum
     uint32_t actual_xsum;
-    actual_xsum = toku_x1764_memory((char *)sb_node_info.compressed_ptr-8, 8+sb_node_info.compressed_size);
+    actual_xsum = toku_x1764_memory((char *)sb_node_info.compressed_ptr - 8,
+                                    8 + sb_node_info.compressed_size);
     if (sb_node_info.xsum != actual_xsum) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+            "file[%s], blocknum[%ld], sb_node_info.xsum[%d] != actual_xsum[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            sb_node_info.xsum,
+            actual_xsum);
+        dump_bad_block(rb->buf, rb->size);
         r = TOKUDB_BAD_CHECKSUM;
         goto cleanup;
     }
@@ -1558,18 +1761,30 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
         toku::scoped_malloc sb_node_info_buf(sb_node_info.uncompressed_size);
         sb_node_info.uncompressed_ptr = sb_node_info_buf.get();
         tokutime_t decompress_t0 = toku_time_now();
-        toku_decompress(
-            (Bytef *) sb_node_info.uncompressed_ptr,
-            sb_node_info.uncompressed_size,
-            (Bytef *) sb_node_info.compressed_ptr,
-            sb_node_info.compressed_size
-            );
+        toku_decompress((Bytef *)sb_node_info.uncompressed_ptr,
+                        sb_node_info.uncompressed_size,
+                        (Bytef *)sb_node_info.compressed_ptr,
+                        sb_node_info.compressed_size);
         tokutime_t decompress_t1 = toku_time_now();
         decompress_time = decompress_t1 - decompress_t0;
 
         // at this point sb->uncompressed_ptr stores the serialized node info.
         r = deserialize_ftnode_info(&sb_node_info, node);
         if (r != 0) {
+            fprintf(
+                stderr,
+                "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+                "file[%s], blocknum[%ld], deserialize_ftnode_info failed with "
+                "%d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                r);
+            dump_bad_block(
+                static_cast<unsigned char *>(sb_node_info.uncompressed_ptr),
+                sb_node_info.uncompressed_size);
+            dump_bad_block(rb->buf, rb->size);
             goto cleanup;
         }
     }
@@ -1594,6 +1809,17 @@ deserialize_ftnode_header_from_rbuf_if_small_enough (FTNODE *ftnode,
         PAIR_ATTR attr;
         r = toku_ftnode_pf_callback(node, *ndd, bfe, fd, &attr);
         if (r != 0) {
+            fprintf(
+                stderr,
+                "%s:%d:deserialize_ftnode_header_from_rbuf_if_small_enough - "
+                "file[%s], blocknum[%ld], toku_ftnode_pf_callback failed with "
+                "%d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                r);
+            dump_bad_block(rb->buf, rb->size);
             goto cleanup;
         }
     }
@@ -1630,12 +1856,10 @@ cleanup:
 // that did not generate MSN's for messages.  These new MSN's are
 // generated from the root downwards, counting backwards from MIN_MSN
 // and persisted in the ft header.
-static int
-deserialize_and_upgrade_internal_node(FTNODE node,
-                                      struct rbuf *rb,
-                                      ftnode_fetch_extra *bfe,
-                                      STAT64INFO info)
-{
+static int deserialize_and_upgrade_internal_node(FTNODE node,
+                                                 struct rbuf *rb,
+                                                 ftnode_fetch_extra *bfe,
+                                                 STAT64INFO info) {
     int version = node->layout_version_read_from_disk;
 
     if (version == FT_LAST_LAYOUT_VERSION_WITH_FINGERPRINT) {
@@ -1900,25 +2124,25 @@ deserialize_and_upgrade_leaf_node(FTNODE node,
     return r;
 }
 
-static int
-read_and_decompress_block_from_fd_into_rbuf(int fd, BLOCKNUM blocknum,
-                                            DISKOFF offset, DISKOFF size,
-                                            FT ft,
-                                            struct rbuf *rb,
-                                            /* out */ int *layout_version_p);
+static int read_and_decompress_block_from_fd_into_rbuf(
+    int fd,
+    BLOCKNUM blocknum,
+    DISKOFF offset,
+    DISKOFF size,
+    FT ft,
+    struct rbuf *rb,
+    /* out */ int *layout_version_p);
 
 // This function upgrades a version 14 or 13 ftnode to the current
 // version. NOTE: This code assumes the first field of the rbuf has
 // already been read from the buffer (namely the layout_version of the
 // ftnode.)
-static int
-deserialize_and_upgrade_ftnode(FTNODE node,
-                                FTNODE_DISK_DATA* ndd,
-                                BLOCKNUM blocknum,
-                                ftnode_fetch_extra *bfe,
-                                STAT64INFO info,
-                                int fd)
-{
+static int deserialize_and_upgrade_ftnode(FTNODE node,
+                                          FTNODE_DISK_DATA *ndd,
+                                          BLOCKNUM blocknum,
+                                          ftnode_fetch_extra *bfe,
+                                          STAT64INFO info,
+                                          int fd) {
     int r = 0;
     int version;
 
@@ -1937,6 +2161,16 @@ deserialize_and_upgrade_ftnode(FTNODE node,
                                                     &rb,
                                                     &version);
     if (r != 0) {
+        const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
+        fprintf(stderr,
+                "%s:%d:deserialize_and_upgrade_ftnode - "
+                "file[%s], blocknum[%ld], "
+                "read_and_decompress_block_from_fd_into_rbuf failed with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                r);
         goto exit;
     }
 
@@ -1952,6 +2186,21 @@ deserialize_and_upgrade_ftnode(FTNODE node,
     // Copy over old version info.
     node->layout_version_read_from_disk = rbuf_int(&rb); // 2. layout version
     version = node->layout_version_read_from_disk;
+    if (version > FT_LAYOUT_VERSION_14) {
+        const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
+        fprintf(stderr,
+                "%s:%d:deserialize_and_upgrade_ftnode - "
+                "file[%s], blocknum[%ld], version[%d] > "
+                "FT_LAYOUT_VERSION_14[%d]\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                version,
+                FT_LAYOUT_VERSION_14);
+        dump_bad_block(rb.buf, rb.size);
+        goto exit;
+    }
     assert(version <= FT_LAYOUT_VERSION_14);
     // Upgrade the current version number to the current version.
     node->layout_version = FT_LAYOUT_VERSION;
@@ -1999,25 +2248,23 @@ exit:
     return r;
 }
 
-static int
-deserialize_ftnode_from_rbuf(
-    FTNODE *ftnode,
-    FTNODE_DISK_DATA* ndd,
-    BLOCKNUM blocknum,
-    uint32_t fullhash,
-    ftnode_fetch_extra *bfe,
-    STAT64INFO info,
-    struct rbuf *rb,
-    int fd
-    )
-// Effect: deserializes a ftnode that is in rb (with pointer of rb just past the magic) into a FTNODE.
-{
+// Effect: deserializes a ftnode that is in rb (with pointer of rb just past the
+// magic) into a FTNODE.
+static int deserialize_ftnode_from_rbuf(FTNODE *ftnode,
+                                        FTNODE_DISK_DATA *ndd,
+                                        BLOCKNUM blocknum,
+                                        uint32_t fullhash,
+                                        ftnode_fetch_extra *bfe,
+                                        STAT64INFO info,
+                                        struct rbuf *rb,
+                                        int fd) {
     int r = 0;
     struct sub_block sb_node_info;
 
     tokutime_t t0, t1;
     tokutime_t decompress_time = 0;
     tokutime_t deserialize_time = 0;
+    const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
 
     t0 = toku_time_now();
 
@@ -2027,8 +2274,26 @@ deserialize_ftnode_from_rbuf(
     // first thing we do is read the header information
     const void *magic;
     rbuf_literal_bytes(rb, &magic, 8);
-    if (memcmp(magic, "tokuleaf", 8)!=0 &&
-        memcmp(magic, "tokunode", 8)!=0) {
+    if (memcmp(magic, "tokuleaf", 8) != 0 &&
+        memcmp(magic, "tokunode", 8) != 0) {
+        fprintf(stderr,
+                "%s:%d:deserialize_ftnode_from_rbuf - "
+                "file[%s], blocknum[%ld], unrecognized magic number "
+                "%2.2x %2.2x %2.2x %2.2x   %2.2x %2.2x %2.2x %2.2x\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                static_cast<const uint8_t *>(magic)[0],
+                static_cast<const uint8_t *>(magic)[1],
+                static_cast<const uint8_t *>(magic)[2],
+                static_cast<const uint8_t *>(magic)[3],
+                static_cast<const uint8_t *>(magic)[4],
+                static_cast<const uint8_t *>(magic)[5],
+                static_cast<const uint8_t *>(magic)[6],
+                static_cast<const uint8_t *>(magic)[7]);
+        dump_bad_block(rb->buf, rb->size);
+
         r = toku_db_badformat();
         goto cleanup;
     }
@@ -2042,6 +2307,16 @@ deserialize_ftnode_from_rbuf(
         // Perform the upgrade.
         r = deserialize_and_upgrade_ftnode(node, ndd, blocknum, bfe, info, fd);
         if (r != 0) {
+            fprintf(stderr,
+                    "%s:%d:deserialize_ftnode_from_rbuf - "
+                    "file[%s], blocknum[%ld], deserialize_and_upgrade_ftnode "
+                    "failed with %d\n",
+                    __FILE__,
+                    __LINE__,
+                    fname ? fname : "unknown",
+                    blocknum.b,
+                    r);
+            dump_bad_block(rb->buf, rb->size);
             goto cleanup;
         }
 
@@ -2077,6 +2352,16 @@ deserialize_ftnode_from_rbuf(
     uint32_t stored_checksum;
     stored_checksum = rbuf_int(rb);
     if (stored_checksum != checksum) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_from_rbuf - "
+            "file[%s], blocknum[%ld], stored_checksum[%d] != checksum[%d]\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            stored_checksum,
+            checksum);
         dump_bad_block(rb->buf, rb->size);
         invariant(stored_checksum == checksum);
     }
@@ -2088,34 +2373,61 @@ deserialize_ftnode_from_rbuf(
         r = read_and_decompress_sub_block(rb, &sb_node_info);
         tokutime_t sb_decompress_t1 = toku_time_now();
         decompress_time += sb_decompress_t1 - sb_decompress_t0;
-    }
-    if (r != 0) {
-        goto cleanup;
+        if (r != 0) {
+            fprintf(
+                stderr,
+                "%s:%d:deserialize_ftnode_from_rbuf - "
+                "file[%s], blocknum[%ld], read_and_decompress_sub_block failed "
+                "with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                blocknum.b,
+                r);
+            dump_bad_block(
+                static_cast<unsigned char *>(sb_node_info.uncompressed_ptr),
+                sb_node_info.uncompressed_size);
+            dump_bad_block(rb->buf, rb->size);
+            goto cleanup;
+        }
     }
 
     // at this point, sb->uncompressed_ptr stores the serialized node info
     r = deserialize_ftnode_info(&sb_node_info, node);
     if (r != 0) {
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_from_rbuf - "
+            "file[%s], blocknum[%ld], deserialize_ftnode_info failed with "
+            "%d\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            r);
+        dump_bad_block(rb->buf, rb->size);
         goto cleanup;
     }
     toku_free(sb_node_info.uncompressed_ptr);
 
-    // now that the node info has been deserialized, we can proceed to deserialize
-    // the individual sub blocks
+    // now that the node info has been deserialized, we can proceed to
+    // deserialize the individual sub blocks
 
     // setup the memory of the partitions
-    // for partitions being decompressed, create either message buffer or basement node
+    // for partitions being decompressed, create either message buffer or
+    //   basement node
     // for partitions staying compressed, create sub_block
     setup_ftnode_partitions(node, bfe, true);
 
-    // This loop is parallelizeable, since we don't have a dependency on the work done so far.
+    // This loop is parallelizeable, since we don't have a dependency on the
+    // work done so far.
     for (int i = 0; i < node->n_children; i++) {
-        uint32_t curr_offset = BP_START(*ndd,i);
-        uint32_t curr_size   = BP_SIZE(*ndd,i);
-        // the compressed, serialized partitions start at where rb is currently pointing,
-        // which would be rb->buf + rb->ndone
+        uint32_t curr_offset = BP_START(*ndd, i);
+        uint32_t curr_size = BP_SIZE(*ndd, i);
+        // the compressed, serialized partitions start at where rb is currently
+        // pointing, which would be rb->buf + rb->ndone
         // we need to intialize curr_rbuf to point to this place
-        struct rbuf curr_rbuf  = {.buf = NULL, .size = 0, .ndone = 0};
+        struct rbuf curr_rbuf = {.buf = nullptr, .size = 0, .ndone = 0};
         rbuf_init(&curr_rbuf, rb->buf + curr_offset, curr_size);
 
         //
@@ -2128,26 +2440,45 @@ deserialize_ftnode_from_rbuf(
         // of the compressed partitions (also possibly none or possibly all)
         // The partitions that we want to decompress and make available
         // to the node, we do, the rest we simply copy in compressed
-        // form into the node, and set the state of the partition to PT_COMPRESSED
+        // form into the node, and set the state of the partition to
+        // PT_COMPRESSED
         //
 
         struct sub_block curr_sb;
         sub_block_init(&curr_sb);
 
-        // curr_rbuf is passed by value to decompress_and_deserialize_worker, so there's no ugly race condition.
+        // curr_rbuf is passed by value to decompress_and_deserialize_worker,
+        // so there's no ugly race condition.
         // This would be more obvious if curr_rbuf were an array.
 
         // deserialize_ftnode_info figures out what the state
         // should be and sets up the memory so that we are ready to use it
 
-        switch (BP_STATE(node,i)) {
-        case PT_AVAIL: {
+        switch (BP_STATE(node, i)) {
+            case PT_AVAIL: {
                 //  case where we read and decompress the partition
                 tokutime_t partition_decompress_time;
-                r = decompress_and_deserialize_worker(curr_rbuf, curr_sb, node, i,
-                                                      bfe->ft->cmp, &partition_decompress_time);
+                r = decompress_and_deserialize_worker(
+                    curr_rbuf,
+                    curr_sb,
+                    node,
+                    i,
+                    bfe->ft->cmp,
+                    &partition_decompress_time);
                 decompress_time += partition_decompress_time;
                 if (r != 0) {
+                    fprintf(
+                        stderr,
+                        "%s:%d:deserialize_ftnode_from_rbuf - "
+                        "file[%s], blocknum[%ld], childnum[%d], "
+                        "decompress_and_deserialize_worker failed with %d\n",
+                        __FILE__,
+                        __LINE__,
+                        fname ? fname : "unknown",
+                        blocknum.b,
+                        i,
+                        r);
+                    dump_bad_block(rb->buf, rb->size);
                     goto cleanup;
                 }
                 break;
@@ -2156,6 +2487,19 @@ deserialize_ftnode_from_rbuf(
             // case where we leave the partition in the compressed state
             r = check_and_copy_compressed_sub_block_worker(curr_rbuf, curr_sb, node, i);
             if (r != 0) {
+                fprintf(
+                    stderr,
+                    "%s:%d:deserialize_ftnode_from_rbuf - "
+                    "file[%s], blocknum[%ld], childnum[%d], "
+                    "check_and_copy_compressed_sub_block_worker failed with "
+                    "%d\n",
+                    __FILE__,
+                    __LINE__,
+                    fname ? fname : "unknown",
+                    blocknum.b,
+                    i,
+                    r);
+                dump_bad_block(rb->buf, rb->size);
                 goto cleanup;
             }
             break;
@@ -2267,8 +2611,10 @@ toku_deserialize_bp_from_disk(FTNODE node, FTNODE_DISK_DATA ndd, int childnum, i
 }
 
 // Take a ftnode partition that is in the compressed state, and make it avail
-int
-toku_deserialize_bp_from_compressed(FTNODE node, int childnum, ftnode_fetch_extra *bfe) {
+int toku_deserialize_bp_from_compressed(FTNODE node,
+                                        int childnum,
+                                        ftnode_fetch_extra *bfe) {
+
     int r = 0;
     assert(BP_STATE(node, childnum) == PT_COMPRESSED);
     SUB_BLOCK curr_sb = BSB(node, childnum);
@@ -2283,16 +2629,30 @@ toku_deserialize_bp_from_compressed(FTNODE node, int childnum, ftnode_fetch_extr
     // decompress the sub_block
     tokutime_t t0 = toku_time_now();
 
-    toku_decompress(
-        (Bytef *) curr_sb->uncompressed_ptr,
-        curr_sb->uncompressed_size,
-        (Bytef *) curr_sb->compressed_ptr,
-        curr_sb->compressed_size
-        );
+    toku_decompress((Bytef *)curr_sb->uncompressed_ptr,
+                    curr_sb->uncompressed_size,
+                    (Bytef *)curr_sb->compressed_ptr,
+                    curr_sb->compressed_size);
 
     tokutime_t t1 = toku_time_now();
 
     r = deserialize_ftnode_partition(curr_sb, node, childnum, bfe->ft->cmp);
+    if (r != 0) {
+        const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
+        fprintf(stderr,
+                "%s:%d:toku_deserialize_bp_from_compressed - "
+                "file[%s], blocknum[%ld], "
+                "deserialize_ftnode_partition failed with %d\n",
+                __FILE__,
+                __LINE__,
+                fname ? fname : "unknown",
+                node->blocknum.b,
+                r);
+        dump_bad_block(static_cast<unsigned char *>(curr_sb->compressed_ptr),
+                       curr_sb->compressed_size);
+        dump_bad_block(static_cast<unsigned char *>(curr_sb->uncompressed_ptr),
+                       curr_sb->uncompressed_size);
+    }
 
     tokutime_t t2 = toku_time_now();
 
@@ -2307,26 +2667,36 @@ toku_deserialize_bp_from_compressed(FTNODE node, int childnum, ftnode_fetch_extr
     return r;
 }
 
-static int
-deserialize_ftnode_from_fd(int fd,
-                            BLOCKNUM blocknum,
-                            uint32_t fullhash,
-                            FTNODE *ftnode,
-                            FTNODE_DISK_DATA *ndd,
-                            ftnode_fetch_extra *bfe,
-                            STAT64INFO info)
-{
+static int deserialize_ftnode_from_fd(int fd,
+                                      BLOCKNUM blocknum,
+                                      uint32_t fullhash,
+                                      FTNODE *ftnode,
+                                      FTNODE_DISK_DATA *ndd,
+                                      ftnode_fetch_extra *bfe,
+                                      STAT64INFO info) {
     struct rbuf rb = RBUF_INITIALIZER;
 
     tokutime_t t0 = toku_time_now();
-    read_block_from_fd_into_rbuf(fd, blocknum, bfe->ft, &rb); 
+    read_block_from_fd_into_rbuf(fd, blocknum, bfe->ft, &rb);
     tokutime_t t1 = toku_time_now();
 
     // Decompress and deserialize the ftnode. Time statistics
     // are taken inside this function.
-    int r = deserialize_ftnode_from_rbuf(ftnode, ndd, blocknum, fullhash, bfe, info, &rb, fd);
+    int r = deserialize_ftnode_from_rbuf(
+        ftnode, ndd, blocknum, fullhash, bfe, info, &rb, fd);
     if (r != 0) {
-        dump_bad_block(rb.buf,rb.size);
+        const char* fname = toku_cachefile_fname_in_env(bfe->ft->cf);
+        fprintf(
+            stderr,
+            "%s:%d:deserialize_ftnode_from_fd - "
+            "file[%s], blocknum[%ld], deserialize_ftnode_from_rbuf failed with "
+            "%d\n",
+            __FILE__,
+            __LINE__,
+            fname ? fname : "unknown",
+            blocknum.b,
+            r);
+        dump_bad_block(rb.buf, rb.size);
     }
 
     bfe->bytes_read = rb.size;
@@ -2335,32 +2705,33 @@ deserialize_ftnode_from_fd(int fd,
     return r;
 }
 
-// Read ftnode from file into struct.  Perform version upgrade if necessary.
-int
-toku_deserialize_ftnode_from (int fd,
-                               BLOCKNUM blocknum,
-                               uint32_t fullhash,
-                               FTNODE *ftnode,
-                               FTNODE_DISK_DATA* ndd,
-                               ftnode_fetch_extra *bfe
-    )
 // Effect: Read a node in.  If possible, read just the header.
-{
+//         Perform version upgrade if necessary.
+int toku_deserialize_ftnode_from(int fd,
+                                 BLOCKNUM blocknum,
+                                 uint32_t fullhash,
+                                 FTNODE *ftnode,
+                                 FTNODE_DISK_DATA *ndd,
+                                 ftnode_fetch_extra *bfe) {
     int r = 0;
     struct rbuf rb = RBUF_INITIALIZER;
 
-    // each function below takes the appropriate io/decompression/deserialize statistics
+    // each function below takes the appropriate io/decompression/deserialize
+    // statistics
 
     if (!bfe->read_all_partitions) {
-        read_ftnode_header_from_fd_into_rbuf_if_small_enough(fd, blocknum, bfe->ft, &rb, bfe);
-        r = deserialize_ftnode_header_from_rbuf_if_small_enough(ftnode, ndd, blocknum, fullhash, bfe, &rb, fd);
+        read_ftnode_header_from_fd_into_rbuf_if_small_enough(
+            fd, blocknum, bfe->ft, &rb, bfe);
+        r = deserialize_ftnode_header_from_rbuf_if_small_enough(
+            ftnode, ndd, blocknum, fullhash, bfe, &rb, fd);
     } else {
         // force us to do it the old way
         r = -1;
     }
     if (r != 0) {
         // Something went wrong, go back to doing it the old way.
-        r = deserialize_ftnode_from_fd(fd, blocknum, fullhash, ftnode, ndd, bfe, NULL);
+        r = deserialize_ftnode_from_fd(
+            fd, blocknum, fullhash, ftnode, ndd, bfe, nullptr);
     }
 
     toku_free(rb.buf);
@@ -2730,12 +3101,14 @@ static int decompress_from_raw_block_into_rbuf_versioned(uint32_t version, uint8
     return r;
 }
 
-static int
-read_and_decompress_block_from_fd_into_rbuf(int fd, BLOCKNUM blocknum,
-                                            DISKOFF offset, DISKOFF size,
-                                            FT ft,
-                                            struct rbuf *rb,
-                                  /* out */ int *layout_version_p) {
+static int read_and_decompress_block_from_fd_into_rbuf(
+    int fd,
+    BLOCKNUM blocknum,
+    DISKOFF offset,
+    DISKOFF size,
+    FT ft,
+    struct rbuf *rb,
+    /* out */ int *layout_version_p) {
     int r = 0;
     if (0) printf("Deserializing Block %" PRId64 "\n", blocknum.b);
 

--- a/ft/serialize/ft_node-serialize.h
+++ b/ft/serialize/ft_node-serialize.h
@@ -46,21 +46,51 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "ft/serialize/block_table.h"
 
 unsigned int toku_serialize_ftnode_size(FTNODE node);
-int toku_serialize_ftnode_to_memory(FTNODE node, FTNODE_DISK_DATA *ndd,
-                                    unsigned int basementnodesize,
-                                    enum toku_compression_method compression_method,
-                                    bool do_rebalancing, bool in_parallel,
-                                    size_t *n_bytes_to_write, size_t *n_uncompressed_bytes,
-                                    char **bytes_to_write);
-int toku_serialize_ftnode_to(int fd, BLOCKNUM, FTNODE node, FTNODE_DISK_DATA *ndd, bool do_rebalancing, FT ft, bool for_checkpoint);
-int toku_serialize_rollback_log_to(int fd, ROLLBACK_LOG_NODE log, SERIALIZED_ROLLBACK_LOG_NODE serialized_log, bool is_serialized,
-                                    FT ft, bool for_checkpoint);
-void toku_serialize_rollback_log_to_memory_uncompressed(ROLLBACK_LOG_NODE log, SERIALIZED_ROLLBACK_LOG_NODE serialized);
+int toku_serialize_ftnode_to_memory(
+    FTNODE node,
+    FTNODE_DISK_DATA *ndd,
+    unsigned int basementnodesize,
+    enum toku_compression_method compression_method,
+    bool do_rebalancing,
+    bool in_parallel,
+    size_t *n_bytes_to_write,
+    size_t *n_uncompressed_bytes,
+    char **bytes_to_write);
+int toku_serialize_ftnode_to(int fd,
+                             BLOCKNUM,
+                             FTNODE node,
+                             FTNODE_DISK_DATA *ndd,
+                             bool do_rebalancing,
+                             FT ft,
+                             bool for_checkpoint);
+int toku_serialize_rollback_log_to(int fd,
+                                   ROLLBACK_LOG_NODE log,
+                                   SERIALIZED_ROLLBACK_LOG_NODE serialized_log,
+                                   bool is_serialized,
+                                   FT ft,
+                                   bool for_checkpoint);
+void toku_serialize_rollback_log_to_memory_uncompressed(
+    ROLLBACK_LOG_NODE log,
+    SERIALIZED_ROLLBACK_LOG_NODE serialized);
 
-int toku_deserialize_rollback_log_from(int fd, BLOCKNUM blocknum, ROLLBACK_LOG_NODE *logp, FT ft);
-int toku_deserialize_bp_from_disk(FTNODE node, FTNODE_DISK_DATA ndd, int childnum, int fd, ftnode_fetch_extra *bfe);
-int toku_deserialize_bp_from_compressed(FTNODE node, int childnum, ftnode_fetch_extra *bfe);
-int toku_deserialize_ftnode_from(int fd, BLOCKNUM off, uint32_t fullhash, FTNODE *node, FTNODE_DISK_DATA *ndd, ftnode_fetch_extra *bfe);
+int toku_deserialize_rollback_log_from(int fd,
+                                       BLOCKNUM blocknum,
+                                       ROLLBACK_LOG_NODE *logp,
+                                       FT ft);
+int toku_deserialize_bp_from_disk(FTNODE node,
+                                  FTNODE_DISK_DATA ndd,
+                                  int childnum,
+                                  int fd,
+                                  ftnode_fetch_extra *bfe);
+int toku_deserialize_bp_from_compressed(FTNODE node,
+                                        int childnum,
+                                        ftnode_fetch_extra *bfe);
+int toku_deserialize_ftnode_from(int fd,
+                                 BLOCKNUM off,
+                                 uint32_t fullhash,
+                                 FTNODE *node,
+                                 FTNODE_DISK_DATA *ndd,
+                                 ftnode_fetch_extra *bfe);
 
 void toku_serialize_set_parallel(bool);
 
@@ -73,9 +103,14 @@ int decompress_from_raw_block_into_rbuf(uint8_t *raw_block, size_t raw_block_siz
 
 // used by verify
 int deserialize_ft_versioned(int fd, struct rbuf *rb, FT *ft, uint32_t version);
-void read_block_from_fd_into_rbuf(int fd, BLOCKNUM blocknum, FT ft, struct rbuf *rb);
+void read_block_from_fd_into_rbuf(int fd,
+                                  BLOCKNUM blocknum,
+                                  FT ft,
+                                  struct rbuf *rb);
 int read_compressed_sub_block(struct rbuf *rb, struct sub_block *sb);
-int verify_ftnode_sub_block(struct sub_block *sb);
+int verify_ftnode_sub_block(struct sub_block *sb,
+                            const char *fname,
+                            BLOCKNUM blocknum);
 void just_decompress_sub_block(struct sub_block *sb);
 
 // used by ft-node-deserialize.cc

--- a/tools/ftverify.cc
+++ b/tools/ftverify.cc
@@ -325,7 +325,7 @@ check_block(BLOCKNUM blocknum, int64_t UU(blocksize), int64_t UU(address), void 
         }
         just_decompress_sub_block(&sb);
 	
-        r = verify_ftnode_sub_block(&sb);
+        r = verify_ftnode_sub_block(&sb, nullptr, blocknum);
         if (r != 0) {
             printf(" Uncompressed child partition %d checksum failed.\n", i);
             failure++;

--- a/tools/tokuftdump.cc
+++ b/tools/tokuftdump.cc
@@ -158,7 +158,8 @@ static void dump_descriptor(DESCRIPTOR d) {
 static void open_header(int fd, FT *header, CACHEFILE cf) {
     FT ft = NULL;
     int r;
-    r = toku_deserialize_ft_from (fd, MAX_LSN, &ft);
+    const char *fn = toku_cachefile_fname_in_env(cf);
+    r = toku_deserialize_ft_from (fd, fn, MAX_LSN, &ft);
     if (r != 0) {
         fprintf(stderr, "%s: can not deserialize from %s error %d\n", arg0, fname, r);
         exit(1);


### PR DESCRIPTION
TDB-23 : PerconaFT can assert when opening a dictionary with no useful information to error log
TDB-24 : PerconaFT asserts for various reasons deserializing nodes with no useful error output