### PR TITLE
TDB-68: PerconaFT fails to build on debian wheezy 64 bit debug

### DIFF
--- a/portability/toku_debug_sync.h
+++ b/portability/toku_debug_sync.h
@@ -43,13 +43,12 @@ struct tokutxn;
 #if defined(ENABLED_DEBUG_SYNC)
 
 /*
-  my_global.h which is included in m_string.h defines __STDC_FORMAT_MACROS,
-  the same macros is defined in TokuSetupCompiler.cmake, undefine it here
-  to avoid build errors
+  the below macros are defined in my_global.h, which is included in m_string.h,
+  the same macros are defined in TokuSetupCompiler.cmake as compiler options,
+  undefine them here to avoid build errors
 */
-#ifdef __STDC_FORMAT_MACROS
 #undef __STDC_FORMAT_MACROS
-#endif // __STDC_FORMAT_MACROS
+#undef __STDC_LIMIT_MACROS
 
 #include "m_string.h"
 #include "debug_sync.h"


### PR DESCRIPTION
Some macros are defined both in build options and mysql files, the fix is in
undefining such macros in the library code to avoid build errors.

Testing: http://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1079/