### PR TITLE
TDB-35: optimizer picks wrong index for tokudb tables having a hot cr…

### DIFF
--- a/src/indexer-undo-do.cc
+++ b/src/indexer-undo-do.cc
@@ -571,6 +571,7 @@ indexer_ft_delete_committed(DB_INDEXER *indexer, DB *hotdb, DBT *hotkey, XIDS xi
                                 oldest_referenced_xid_estimate,
                                 true);
             toku_ft_send_delete(db_struct_i(hotdb)->ft_handle, hotkey, xids, &gc_info);
+            toku_ft_adjust_logical_row_count(db_struct_i(hotdb)->ft_handle->ft, -1);
         }
     }
     return result;
@@ -616,6 +617,7 @@ indexer_ft_insert_committed(DB_INDEXER *indexer, DB *hotdb, DBT *hotkey, DBT *ho
                                 oldest_referenced_xid_estimate,
                                 true);
             toku_ft_send_insert(db_struct_i(hotdb)->ft_handle, hotkey, hotval, xids, FT_INSERT, &gc_info);
+            toku_ft_adjust_logical_row_count(db_struct_i(hotdb)->ft_handle->ft, 1);
         }
     }
     return result;


### PR DESCRIPTION
Updated: Rebased and Retested. 

Jenkin: http://jenkins.percona.com/view/TokuDB/job/PerconaFT-param/104/

[TDB-35]optimizer picks wrong index for tokudb tables having a hot created index

https://jira.percona.com/browse/TDB-35
http://jenkins.percona.com/view/TokuDB/job/PerconaFT-param/99/

The # of row was not calculated correctly during the recreation of the indexes.
The in_mem_logical_rows of two indexes (i1 and i2 as refered in the test report)
are both 0, which should be 10,000. The experiments show (1) the logical row count
logic looks well maintained most of time (2) the bug only occurs when the following
flow is executed: 1) data creation like adding 10000 entries 2) then drop the indexes
3) then create hot index.  From the step two forward, it seemed like the recreated
index has in_mem_logical_rows=0 instead of 10000.  If we keep on inserting more data,
let's say, another 9999 entries, then in_mem_stats got updated correctly to 19999
while in_mem_logical_row only picked 9999. This confirms (1) the basic logic of
maintaining logical rows still works (2) the bug exists in the recreation of the indexes.

When a hot index is built, there is a step of copying the dbts from the main table
to the secondary index table, and this copy seems to bypass current the logical row count
paths that have been instrumented.

In the src/indexer-undo-do.cc, the adjustments of logical row count are now being added.