### PR TITLE
TDB-75: PerconaFT does not build standalone or with -DBUILD_TESTING=ON

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -204,6 +204,9 @@ toku_instr_key *result_i_open_dbs_rwlock_key;
 // locktree
 toku_instr_key *lock_request_m_wait_cond_key;
 toku_instr_key *manager_m_escalator_done_key;
+toku_instr_key *locktree_request_info_mutex_key;
+toku_instr_key *locktree_request_info_retry_mutex_key;
+toku_instr_key *locktree_request_info_retry_cv_key;
 
 // this is a sample probe for custom instrumentation
 static toku_instr_key *fti_probe_1_key;

--- a/locktree/locktree.cc
+++ b/locktree/locktree.cc
@@ -51,10 +51,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 // the locktree source file instead of the header.
 #include "concurrent_tree.h"
 
-toku_instr_key *locktree_request_info_mutex_key;
-toku_instr_key *locktree_request_info_retry_mutex_key;
-toku_instr_key *locktree_request_info_retry_cv_key;
-
 namespace toku {
 
 // A locktree represents the set of row locks owned by all transactions


### PR DESCRIPTION
The problem is that some tests are not linked to liblocktree, and must not be
linked logically, because the structure of the code assumes that some directory
in the code contains the code for the separate library, and the tests inside
such directory test the corresponding library. At the other hand liblocktree
contained the definition of some PFS keys which were used inside of locktree
code, but that keys are initialized in ft-ops.cc which is the part of libft
library. So when libft is used without liblocktree there are "undefined symbol"
errors.

The solution is to move that keys definition from locktree.cc to ft-ops.cc.