### PR TITLE
TDB-74 : PerconaFT encodes already encoded database name for director…

### DIFF
--- a/src/ydb_db.h
+++ b/src/ydb_db.h
@@ -122,8 +122,7 @@ toku_db_destruct_autotxn(DB_TXN *txn, int r, bool changed) {
     return r; 
 }
 
-void create_iname_hint_for_dbdir(const char *dname, char *hint);
-void create_iname_hint(const char *dname, char *hint);
+void create_iname_hint(DB_ENV *env, const char *dname, char *hint);
 char *create_iname(DB_ENV *env,
                    uint64_t id1,
                    uint64_t id2,


### PR DESCRIPTION
TDB-74 : PerconaFT encodes already encoded database name for directory name
  - PerconaFT encodes all single or runs of non alphanumeric characters in a
    dictionary name into a single underscore ('_'). When dir-per-db is in use,
    this extends to the target directory name for the 'database'.
  - This fix, prevents this transformation on the 'directory' portion of the
    dictionary name when dir-per-db is enabled and assumes that the caller has
    already scrubbed and encoded the name in a way that is safe for the underlying
    filesystem.
