### PR TITLE
 [FT-681] Transactional inconsistency with rollback

### DIFF
--- a/ft/txn/rollback-apply.cc
+++ b/ft/txn/rollback-apply.cc
@@ -239,6 +239,7 @@ int toku_rollback_commit(TOKUTXN txn, LSN lsn) {
             // Append the list to the front of the parent.
             if (child_log->oldest_logentry) {
                 // There are some entries, so link them in.
+                parent_log->dirty = true;
                 child_log->oldest_logentry->prev = parent_log->newest_logentry;
                 if (!parent_log->oldest_logentry) {
                     parent_log->oldest_logentry = child_log->oldest_logentry;

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -53,7 +53,7 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
   target_link_libraries(test-5138.tdb ${LIBTOKUDB}_static z ${LIBTOKUPORTABILITY}_static ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
   add_space_separated_property(TARGET test-5138.tdb COMPILE_FLAGS -fvisibility=hidden)
   add_ydb_test(test-5138.tdb)
-
+  add_ydb_test(rollback-inconsistency.tdb)
   foreach(bin ${tdb_bins})
     get_filename_component(base ${bin} NAME_WE)
 

--- a/src/tests/rollback-inconsistency.cc
+++ b/src/tests/rollback-inconsistency.cc
@@ -1,0 +1,161 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+This file is part of PerconaFT.
+
+
+Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+#ident "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved."
+
+#include "test.h"
+
+// insert enough rows with a child txn and then force an eviction to verify the rollback
+// log node is in valid state.
+// the test fails without the fix (and of course passes with it).
+// The test basically simulates the test script of George's. 
+
+
+static void
+populate_table(int start, int end, DB_TXN * parent, DB_ENV * env, DB * db) {
+    DB_TXN *txn = NULL;
+    int r = env->txn_begin(env, parent, &txn, 0); assert_zero(r);
+    for (int i = start; i < end; i++) {
+        int k = htonl(i);
+        char kk[4]; 
+        char str[220];
+        memset(kk, 0, sizeof kk);
+        memcpy(kk, &k, sizeof k);
+        memset(str,'a', sizeof str-1);
+        DBT key = { .data = kk, .size = sizeof kk };
+        DBT val = { .data = str, .size = 220 };
+        r = db->put(db, txn, &key, &val, 0);
+        assert_zero(r);
+    }
+    r = txn->commit(txn, 0); 
+    assert_zero(r);
+}
+
+static void
+populate_and_test(DB_ENV *env, DB *db) {
+    int r;
+    DB_TXN *parent = NULL;
+    r = env->txn_begin(env, NULL, &parent, 0); assert_zero(r);
+    
+    populate_table(0, 128, parent, env, db);
+
+    //we know the eviction is going to happen here and the log node of parent txn is going to be evicted
+    //due to the extremely low cachesize. 
+    populate_table(128, 256, parent, env, db);
+   
+    //again eviction due to the memory pressure. 256 rows is the point when that rollback log spills out. The spilled node
+    //will be written back but will not be dirtied by including rollback nodes from child txn(in which case the bug is bypassed).
+    populate_table(256, 512, parent, env, db);
+    
+    r = parent->abort(parent); assert_zero(r);
+    
+    //try to search anything in the lost range
+    int k = htonl(200);
+    char kk[4]; 
+    memset(kk, 0, sizeof kk);
+    memcpy(kk, &k, sizeof k);
+    DBT key = { .data = kk, .size = sizeof kk };
+    DBT val;
+    r = db->get(db, NULL, &key, &val, 0);
+    assert(r==DB_NOTFOUND);
+
+}
+
+static void
+run_test(void) {
+    int r;
+    DB_ENV *env = NULL;
+    r = db_env_create(&env, 0); 
+    assert_zero(r);
+    env->set_errfile(env, stderr);
+  
+    //setting up the cachetable size 64k
+    uint32_t cachesize = 64*1024;
+    r = env->set_cachesize(env, 0, cachesize, 1); 
+    assert_zero(r);
+
+    //setting up the log write block size to 4k so the rollback log nodes spill in accordance with the node size
+    r = env->set_lg_bsize(env, 4096);                                                   
+    assert_zero(r);
+    
+    r = env->open(env, TOKU_TEST_FILENAME, DB_INIT_MPOOL|DB_CREATE|DB_THREAD |DB_INIT_LOCK|DB_INIT_LOG|DB_INIT_TXN|DB_PRIVATE, S_IRWXU+S_IRWXG+S_IRWXO); 
+    assert_zero(r);
+
+    DB *db = NULL;
+    r = db_create(&db, env, 0); 
+    assert_zero(r);
+    
+    r = db->set_pagesize(db, 4096);
+    assert_zero(r);
+    
+    r = db->set_readpagesize(db, 1024);
+    assert_zero(r);
+ 
+    r = db->open(db, NULL, "test.tdb", NULL, DB_BTREE, DB_AUTO_COMMIT+DB_CREATE, S_IRWXU+S_IRWXG+S_IRWXO); 
+    assert_zero(r);
+
+    populate_and_test(env, db);
+
+    r = db->close(db, 0); assert_zero(r);
+
+    r = env->close(env, 0); assert_zero(r);
+}
+
+int
+test_main(int argc, char * const argv[]) {
+    int r;
+
+    // parse_args(argc, argv);
+    for (int i = 1; i < argc; i++) {
+        char * const arg = argv[i];
+        if (strcmp(arg, "-v") == 0) {
+            verbose++;
+            continue;
+        }
+        if (strcmp(arg, "-q") == 0) {
+            verbose = 0;
+            continue;
+        }
+    }
+
+    toku_os_recursive_delete(TOKU_TEST_FILENAME);
+    r = toku_os_mkdir(TOKU_TEST_FILENAME, S_IRWXU+S_IRWXG+S_IRWXO); assert_zero(r);
+
+    run_test();
+
+    return 0;
+}
+


### PR DESCRIPTION
            1. Essentially, we use the cachetable to keep the undo logs in the memory by saving the
            undo entries into the rollback_log_nodes. When we have a large sequential inserts within
            one txn, the rollback_log_node will grow and then spill out when it is beyond block_size
            and there is a chance that undo log ends up being written to the disk upon checkpoint or
            eviction.

            The complication arises when a child txn commits and all of its undo logs gets merged
            into that of its parent txn. This is done through swinging the log entry list from the
            rollback_log_node of the child txn to that of the parent txn. But the impl had forgotten
            to dirty the parent rollback_log_node...without any assertions, the bug is very hard to
            manifest because the node is considered clean and gets evicted without flushing when under
            the memory presure, which means the loss of the log entries, but no warning or failures.

            2. added the ctest src/tests/test-ft-681.cc, which basically simulates George's sql script.

            before the fix, the test failed with
            test-ft-681.cc:121 populate: Assertion `r==DB_NOTFOUND' failed (errno=2)

            after the fix, the test should just pass.