### PR TITLE
tests: compile error on arches where char is unsigned

### DIFF
--- a/src/tests/recovery_fileops_unit.cc
+++ b/src/tests/recovery_fileops_unit.cc
@@ -158,7 +158,7 @@ do_args(int argc, char * const argv[]) {
         choices[i] = -1;
     }
 
-    char c;
+    signed char c;
     while ((c = getopt(argc, argv, "vqhcrO:A:B:C:D:E:F:G:H:I:J:X:")) != -1) {
         switch (c) {
             case 'v':


### PR DESCRIPTION
As the signed nature of char isn't specified in the C standard and we are using in a signed context here I'm making this explicit.

Compile error was:

src/tests/recovery_fileops_unit.cc:162:70: error: comparison is always true due to limited range of data type [-Werror=type-limits]
     while ((c = getopt(argc, argv, "vqhcrO:A:B:C:D:E:F:G:H:I:J:X:")) != -1) {
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
cc1plus: all warnings being treated as errors

$CXX --version (Power 8 Architecture)
g++ (GCC) 6.3.1 20170515