### PR TITLE
Add POWER implementation for toku_time_now

### DIFF
--- a/portability/toku_time.h
+++ b/portability/toku_time.h
@@ -43,6 +43,9 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <time.h>
 #include <sys/time.h>
 #include <stdint.h>
+#if defined(__powerpc__)
+# include <sys/platform/ppc.h>
+#endif
 
 static inline float toku_tdiff (struct timeval *a, struct timeval *b) {
     return (float)((a->tv_sec - b->tv_sec) + 1e-6 * (a->tv_usec - b->tv_usec));
@@ -106,6 +109,8 @@ static inline tokutime_t toku_time_now(void) {
     uint64_t result;
     __asm __volatile__ ("mrs %[rt], cntvct_el0" : [rt] "=r" (result));
     return result;
+#elif defined(__powerpc__)
+    return __ppc_get_timebase();
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
One of the big gaps in Power enabled for tokudb was this function being missing.