### PR TITLE
pfs leaks memory

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -4880,6 +4880,94 @@ static void toku_pfs_keys_init(const char *toku_instr_group_name) {
     toku_instr_probe_1 = new toku_instr_probe(*fti_probe_1_key);
 }
 
+static void toku_pfs_keys_destroy(void) {
+    delete kibbutz_mutex_key;
+    delete minicron_p_mutex_key;
+    delete queue_result_mutex_key;
+    delete tpool_lock_mutex_key;
+    delete workset_lock_mutex_key;
+    delete bjm_jobs_lock_mutex_key;
+    delete log_internal_lock_mutex_key;
+    delete cachetable_ev_thread_lock_mutex_key;
+    delete cachetable_disk_nb_mutex_key;
+    delete safe_file_size_lock_mutex_key;
+    delete cachetable_m_mutex_key;
+    delete checkpoint_safe_mutex_key;
+    delete ft_ref_lock_mutex_key;
+    delete ft_open_close_lock_mutex_key;
+    delete loader_error_mutex_key;
+    delete bfs_mutex_key;
+    delete loader_bl_mutex_key;
+    delete loader_fi_lock_mutex_key;
+    delete loader_out_mutex_key;
+    delete result_output_condition_lock_mutex_key;
+    delete block_table_mutex_key;
+    delete rollback_log_node_cache_mutex_key;
+    delete txn_lock_mutex_key;
+    delete txn_state_lock_mutex_key;
+    delete txn_child_manager_mutex_key;
+    delete txn_manager_lock_mutex_key;
+    delete treenode_mutex_key;
+    delete locktree_request_info_mutex_key;
+    delete locktree_request_info_retry_mutex_key;
+    delete manager_mutex_key;
+    delete manager_escalation_mutex_key;
+    delete db_txn_struct_i_txn_mutex_key;
+    delete manager_escalator_mutex_key;
+    delete indexer_i_indexer_lock_mutex_key;
+    delete indexer_i_indexer_estimate_lock_mutex_key;
+
+    delete tokudb_file_data_key;
+    delete tokudb_file_load_key;
+    delete tokudb_file_tmp_key;
+    delete tokudb_file_log_key;
+
+    delete fti_probe_1_key;
+
+    delete extractor_thread_key;
+    delete fractal_thread_key;
+    delete io_thread_key;
+    delete eviction_thread_key;
+    delete kibbutz_thread_key;
+    delete minicron_thread_key;
+    delete tp_internal_thread_key;
+
+    delete result_state_cond_key;
+    delete bjm_jobs_wait_key;
+    delete cachetable_p_refcount_wait_key;
+    delete cachetable_m_flow_control_cond_key;
+    delete cachetable_m_ev_thread_cond_key;
+    delete bfs_cond_key;
+    delete result_output_condition_key;
+    delete manager_m_escalator_done_key;
+    delete lock_request_m_wait_cond_key;
+    delete queue_result_cond_key;
+    delete ws_worker_wait_key;
+    delete rwlock_wait_read_key;
+    delete rwlock_wait_write_key;
+    delete rwlock_cond_key;
+    delete tp_thread_wait_key;
+    delete tp_pool_wait_free_key;
+    delete frwlock_m_wait_read_key;
+    delete kibbutz_k_cond_key;
+    delete minicron_p_condvar_key;
+    delete locktree_request_info_retry_cv_key;
+
+    delete multi_operation_lock_key;
+    delete low_priority_multi_operation_lock_key;
+    delete cachetable_m_list_lock_key;
+    delete cachetable_m_pending_lock_expensive_key;
+    delete cachetable_m_pending_lock_cheap_key;
+    delete cachetable_m_lock_key;
+    delete result_i_open_dbs_rwlock_key;
+    delete checkpoint_safe_rwlock_key;
+    delete cachetable_value_key;
+    delete safe_file_size_lock_rwlock_key;
+
+    delete cachetable_disk_nb_rwlock_key;
+    delete toku_instr_probe_1;
+}
+
 int toku_ft_layer_init(void) {
     int r = 0;
 
@@ -4916,8 +5004,7 @@ void toku_ft_layer_destroy(void) {
     toku_status_destroy();
     partitioned_counters_destroy();
     toku_scoped_malloc_destroy();
-
-    delete toku_instr_probe_1;
+    toku_pfs_keys_destroy();
 
     // Portability must be cleaned up last
     toku_portability_destroy();

--- a/ft/serialize/ft-serialize.cc
+++ b/ft/serialize/ft-serialize.cc
@@ -417,8 +417,10 @@ static size_t serialize_ft_min_size(uint32_t version) {
     switch (version) {
         case FT_LAYOUT_VERSION_29:
             size += sizeof(uint64_t);  // logrows in ft
+            /* fall through */
         case FT_LAYOUT_VERSION_28:
             size += sizeof(uint32_t);  // fanout in ft
+            /* fall through */
         case FT_LAYOUT_VERSION_27:
         case FT_LAYOUT_VERSION_26:
         case FT_LAYOUT_VERSION_25:
@@ -427,10 +429,12 @@ static size_t serialize_ft_min_size(uint32_t version) {
         case FT_LAYOUT_VERSION_22:
         case FT_LAYOUT_VERSION_21:
             size += sizeof(MSN);  // max_msn_in_ft
+            /* fall through */
         case FT_LAYOUT_VERSION_20:
         case FT_LAYOUT_VERSION_19:
             size += 1;            // compression method
             size += sizeof(MSN);  // highest_unused_msn_for_upgrade
+            /* fall through */
         case FT_LAYOUT_VERSION_18:
             size += sizeof(uint64_t);  // time_of_last_optimize_begin
             size += sizeof(uint64_t);  // time_of_last_optimize_end
@@ -438,9 +442,11 @@ static size_t serialize_ft_min_size(uint32_t version) {
             size += sizeof(MSN);  // msn_at_start_of_last_completed_optimize
             size -= 8;            // removed num_blocks_to_upgrade_14
             size -= 8;            // removed num_blocks_to_upgrade_13
+            /* fall through */
         case FT_LAYOUT_VERSION_17:
             size += 16;
             invariant(sizeof(STAT64INFO_S) == 16);
+            /* fall through */
         case FT_LAYOUT_VERSION_16:
         case FT_LAYOUT_VERSION_15:
             size += 4;  // basement node size
@@ -448,8 +454,10 @@ static size_t serialize_ft_min_size(uint32_t version) {
                         // num_blocks_to_upgrade, now one int each for upgrade
                         // from 13, 14
             size += 8;  // time of last verification
+            /* fall through */
         case FT_LAYOUT_VERSION_14:
             size += 8;  // TXNID that created
+            /* fall through */
         case FT_LAYOUT_VERSION_13:
             size += (4  // build_id
                      +
@@ -459,7 +467,7 @@ static size_t serialize_ft_min_size(uint32_t version) {
                      +
                      8  // time_of_last_modification
                      );
-        // fall through
+            /* fall through */
         case FT_LAYOUT_VERSION_12:
             size += (+8  // "tokudata"
                      +

--- a/ft/tests/ft-clock-test.cc
+++ b/ft/tests/ft-clock-test.cc
@@ -184,11 +184,11 @@ static void test2(int fd, FT ft_h, FTNODE *dn) {
     PAIR_ATTR attr;
     memset(&attr, 0, sizeof(attr));
     toku_ftnode_pe_callback(*dn, attr, ft_h, def_pe_finalize_impl, nullptr);
-    invariant(BP_STATE(*dn, 0) == (is_leaf) ? PT_ON_DISK : PT_COMPRESSED);
+    invariant(BP_STATE(*dn, 0) == ((is_leaf) ? PT_ON_DISK : PT_COMPRESSED));
     invariant(BP_STATE(*dn, 1) == PT_AVAIL);
     invariant(BP_SHOULD_EVICT(*dn, 1));
     toku_ftnode_pe_callback(*dn, attr, ft_h, def_pe_finalize_impl, nullptr);
-    invariant(BP_STATE(*dn, 1) == (is_leaf) ? PT_ON_DISK : PT_COMPRESSED);
+    invariant(BP_STATE(*dn, 1) == ((is_leaf) ? PT_ON_DISK : PT_COMPRESSED));
 
     bool req = toku_ftnode_pf_req_callback(*dn, &bfe_subset);
     invariant(req);

--- a/ft/tests/log-test4.cc
+++ b/ft/tests/log-test4.cc
@@ -54,7 +54,7 @@ test_main (int argc __attribute__((__unused__)),
     {
 	ml_lock(&logger->input_lock);
 	toku_logger_make_space_in_inbuf(logger, 5);
-	snprintf(logger->inbuf.buf+logger->inbuf.n_in_buf, 5, "a1234");
+	memcpy(logger->inbuf.buf+logger->inbuf.n_in_buf, "a1234", 5);
 	logger->inbuf.n_in_buf+=5;
 	logger->lsn.lsn++;
 	logger->inbuf.max_lsn_in_buf = logger->lsn;

--- a/portability/toku_instrumentation.h
+++ b/portability/toku_instrumentation.h
@@ -52,6 +52,8 @@ class toku_instr_key {
                    UU(const char *name)) {}
 
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
+
+    ~toku_instr_key() {}
 };
 
 typedef toku_instr_probe_empty toku_instr_probe;

--- a/src/tests/checkpoint_stress.cc
+++ b/src/tests/checkpoint_stress.cc
@@ -351,7 +351,7 @@ test_main (int argc, char * const argv[]) {
                 // arg that suppresses valgrind on this child process
                 break;
             }
-            // otherwise, fall through to an error
+            /* fall through */ // otherwise, fall through to an error
 	case 'h':
         case '?':
             usage(argv[0]);

--- a/src/tests/loader-cleanup-test.cc
+++ b/src/tests/loader-cleanup-test.cc
@@ -172,12 +172,12 @@ err_type_str (enum test_type t) {
     case einval_o:       return "open";
     case enospc_fc:      return "fclose";
     case abort_via_poll: return "abort_via_poll";
-    case commit:         assert(0);
-    case abort_txn:      assert(0);
-    case abort_loader:   assert(0);
+    case commit:         abort();
+    case abort_txn:      abort();
+    case abort_loader:   abort();
     }
     // I know that Barry prefers the single-return case, but writing the code this way means that the compiler will complain if I forget something in the enum. -Bradley
-    assert(0);
+    abort();
     return NULL;
 }
 
@@ -193,12 +193,12 @@ err_msg_type_str (enum test_type t) {
     case einval_o:       return "EINVAL";
     case enospc_fc:      return "ENOSPC";
     case abort_via_poll: return "non-zero";
-    case commit:         assert(0);
-    case abort_txn:      assert(0);
-    case abort_loader:   assert(0);
+    case commit:         abort();
+    case abort_txn:      abort();
+    case abort_loader:   abort();
     }
     // I know that Barry prefers the single-return case, but writing the code this way means that the compiler will complain if I forget something in the enum. -Bradley
-    assert(0);
+    abort();
     return NULL;
 }
 
@@ -873,7 +873,7 @@ static void run_test(enum test_type t, int trigger)
     case abort_via_poll:
 	poll_count_trigger  = trigger;       break;
     default:
-	assert(0);
+	abort();
     }
 
 

--- a/src/tests/recover-del-multiple-abort.cc
+++ b/src/tests/recover-del-multiple-abort.cc
@@ -81,7 +81,7 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
         memcpy(dest_key->data, &pri_data[dbnum], dest_key->size);
         break;
     default:
-        assert(0);
+        abort();
     }
 
     if (dest_val) {
@@ -95,9 +95,9 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
             }
             break;
         case DB_DBT_REALLOC:
-            assert(0);
+            abort();
         default:
-            assert(0);
+            abort();
         }
     }
     

--- a/src/tests/recover-del-multiple-srcdb-fdelete-all.cc
+++ b/src/tests/recover-del-multiple-srcdb-fdelete-all.cc
@@ -85,7 +85,7 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
         memcpy(dest_key->data, &pri_data[dbnum], dest_key->size);
         break;
     default:
-        assert(0);
+        abort();
     }
 
     if (dest_val) {
@@ -99,9 +99,9 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
             }
             break;
         case DB_DBT_REALLOC:
-            assert(0);
+            abort();
         default:
-            assert(0);
+            abort();
         }
     }
     

--- a/src/tests/recover-del-multiple.cc
+++ b/src/tests/recover-del-multiple.cc
@@ -84,7 +84,7 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
         memcpy(dest_key->data, &pri_data[dbnum], dest_key->size);
         break;
     default:
-        assert(0);
+        abort();
     }
 
     if (dest_val) {
@@ -98,9 +98,9 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
             }
             break;
         case DB_DBT_REALLOC:
-            assert(0);
+            abort();
         default:
-            assert(0);
+            abort();
         }
     }
     

--- a/src/tests/recover-put-multiple-abort.cc
+++ b/src/tests/recover-put-multiple-abort.cc
@@ -81,7 +81,7 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
         memcpy(dest_key->data, &pri_data[dbnum], dest_key->size);
         break;
     default:
-        assert(0);
+        abort();
     }
 
     if (dest_val) {
@@ -95,9 +95,9 @@ put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals
             }
             break;
         case DB_DBT_REALLOC:
-            assert(0);
+            abort();
         default:
-            assert(0);
+            abort();
         }
     }
     

--- a/src/tests/recovery_fileops_unit.cc
+++ b/src/tests/recovery_fileops_unit.cc
@@ -217,7 +217,7 @@ do_args(int argc, char * const argv[]) {
                     // arg that suppresses valgrind on this child process
                     break;
                 }
-            // otherwise, fall through to an error
+                /* fall through */ // otherwise, fall through to an error
 	default:
             usage();
             break;

--- a/src/tests/test-prepare3.cc
+++ b/src/tests/test-prepare3.cc
@@ -128,6 +128,7 @@ static void check_prepared_list (enum prepared_state ps[NTXNS], long count, DB_P
 	    goto next;
 	case PREPARED:
 	    count_prepared++;
+            /* fall through */
 	case MAYBE_COMMITTED:
 	case MAYBE_ABORTED:
 	    count_maybe_prepared++;

--- a/util/dbt.cc
+++ b/util/dbt.cc
@@ -199,7 +199,7 @@ int toku_dbt_set(uint32_t len, const void *val, DBT *d, struct simple_dbt *sdbt)
         case (DB_DBT_MALLOC):
             d->data = NULL;
             d->ulen = 0;
-            //Fall through to DB_DBT_REALLOC
+            /* fall through */
         case (DB_DBT_REALLOC):
             if (d->ulen < len) {
                 d->ulen = len*2;


### PR DESCRIPTION
Need to cleanup the pfs memory in the fractal tree library destructor. Detected with valgrind's memory checker (ctest -D ExperimentalMemCheck).

Copyright (c) 2017, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.