### PR TITLE
lp1733637, BLD-861: Fixed compilation issues with gcc 7 and Werror

### DIFF
--- a/ft/loader/loader.cc
+++ b/ft/loader/loader.cc
@@ -1078,7 +1078,7 @@ static void* extractor_thread (void *blv) {
     FTLOADER bl = (FTLOADER)blv;
     int r = 0;
     while (1) {
-        void *item;
+        void *item = nullptr;
         {
             int rq = toku_queue_deq(bl->primary_rowset_queue, &item, NULL, NULL);
             if (rq==EOF) break;
@@ -3336,7 +3336,7 @@ static int write_nonleaves (FTLOADER bl, FIDX pivots_fidx, struct dbout *out, st
         while (sts->n_subtrees - n_subtrees_used >= n_per_block*2) {
             // grab the first N_PER_BLOCK and build a node.
             DBT *pivots;
-            int64_t blocknum_of_new_node;
+            int64_t blocknum_of_new_node = 0;
             struct subtree_info *subtree_info;
             int r = setup_nonleaf_block (n_per_block,
                                          sts, pivots_fidx, n_subtrees_used,

--- a/ft/serialize/ft-serialize.cc
+++ b/ft/serialize/ft-serialize.cc
@@ -417,8 +417,10 @@ static size_t serialize_ft_min_size(uint32_t version) {
     switch (version) {
         case FT_LAYOUT_VERSION_29:
             size += sizeof(uint64_t);  // logrows in ft
+            // fallthrough
         case FT_LAYOUT_VERSION_28:
             size += sizeof(uint32_t);  // fanout in ft
+            // fallthrough
         case FT_LAYOUT_VERSION_27:
         case FT_LAYOUT_VERSION_26:
         case FT_LAYOUT_VERSION_25:
@@ -427,10 +429,12 @@ static size_t serialize_ft_min_size(uint32_t version) {
         case FT_LAYOUT_VERSION_22:
         case FT_LAYOUT_VERSION_21:
             size += sizeof(MSN);  // max_msn_in_ft
+            // fallthrough
         case FT_LAYOUT_VERSION_20:
         case FT_LAYOUT_VERSION_19:
             size += 1;            // compression method
             size += sizeof(MSN);  // highest_unused_msn_for_upgrade
+            // fallthrough
         case FT_LAYOUT_VERSION_18:
             size += sizeof(uint64_t);  // time_of_last_optimize_begin
             size += sizeof(uint64_t);  // time_of_last_optimize_end
@@ -438,9 +442,11 @@ static size_t serialize_ft_min_size(uint32_t version) {
             size += sizeof(MSN);  // msn_at_start_of_last_completed_optimize
             size -= 8;            // removed num_blocks_to_upgrade_14
             size -= 8;            // removed num_blocks_to_upgrade_13
+            // fallthrough
         case FT_LAYOUT_VERSION_17:
             size += 16;
             invariant(sizeof(STAT64INFO_S) == 16);
+            // fallthrough
         case FT_LAYOUT_VERSION_16:
         case FT_LAYOUT_VERSION_15:
             size += 4;  // basement node size
@@ -448,8 +454,10 @@ static size_t serialize_ft_min_size(uint32_t version) {
                         // num_blocks_to_upgrade, now one int each for upgrade
                         // from 13, 14
             size += 8;  // time of last verification
+            // fallthrough
         case FT_LAYOUT_VERSION_14:
             size += 8;  // TXNID that created
+            // fallthrough
         case FT_LAYOUT_VERSION_13:
             size += (4  // build_id
                      +
@@ -459,7 +467,7 @@ static size_t serialize_ft_min_size(uint32_t version) {
                      +
                      8  // time_of_last_modification
                      );
-        // fall through
+            // fallthrough
         case FT_LAYOUT_VERSION_12:
             size += (+8  // "tokudata"
                      +

--- a/util/dbt.cc
+++ b/util/dbt.cc
@@ -199,7 +199,8 @@ int toku_dbt_set(uint32_t len, const void *val, DBT *d, struct simple_dbt *sdbt)
         case (DB_DBT_MALLOC):
             d->data = NULL;
             d->ulen = 0;
-            //Fall through to DB_DBT_REALLOC
+            // fallthrough
+            // to DB_DBT_REALLOC
         case (DB_DBT_REALLOC):
             if (d->ulen < len) {
                 d->ulen = len*2;


### PR DESCRIPTION
* Initialized some variables which were possibly uninitailized before
* Added fallthrough comments, or changed existing comments to the format gcc understands by default