### PR TITLE
Fixing clang warnings/errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,12 @@ project(TokuDB)
 set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS "")
 set(CMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS "")
 
+# See: https://jira.percona.com/browse/TDB-93
+IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-address-of-packed-member")
+  SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-address-of-packed-member")
+ENDIF()
+
 # detect when we are being built as a subproject
 if (DEFINED MYSQL_PROJECT_NAME_DOCSTRING)
   add_definitions( -DMYSQL_TOKUDB_ENGINE=1)

--- a/portability/toku_portability.h
+++ b/portability/toku_portability.h
@@ -157,7 +157,7 @@ extern "C" {
 #endif
 
 // Deprecated functions.
-#if !defined(TOKU_ALLOW_DEPRECATED)
+#if !defined(TOKU_ALLOW_DEPRECATED) && !defined(__clang__)
 int      creat(const char *pathname, mode_t mode)   __attribute__((__deprecated__));
 int      fstat(int fd, struct stat *buf)            __attribute__((__deprecated__));
 int      stat(const char *path, struct stat *buf)   __attribute__((__deprecated__));

--- a/portability/toku_pthread.h
+++ b/portability/toku_pthread.h
@@ -168,11 +168,7 @@ typedef struct toku_mutex_aligned {
     }
 #else  // __linux__, at least
 #define ZERO_COND_INITIALIZER \
-    {                         \
-        {                     \
-            { 0 }             \
-        }                     \
-    }
+    {}
 #endif
 
 static inline void toku_mutexattr_init(toku_pthread_mutexattr_t *attr) {


### PR DESCRIPTION
TDB-93 : Unaligned pointers in perconaFT
* Ignoring a warning about unaligned pointers
* Changed the zero cond initializer: C++ doesn't need a zero, that's C
* Disabled deprecation warnings for stdc functions with Clang: it doesn't allow different function declarations