### PR TITLE
Fix a data race on the transaction rollback log found by the thread sanitizer

### DIFF
--- a/ft/txn/rollback-apply.cc
+++ b/ft/txn/rollback-apply.cc
@@ -230,8 +230,10 @@ int toku_rollback_commit(TOKUTXN txn, LSN lsn) {
 
         //If this transaction needs an fsync (if it commits)
         //save that in the parent.  Since the commit really happens in the root txn.
+        toku_txn_lock(txn->parent);
         txn->parent->force_fsync_on_commit |= txn->force_fsync_on_commit;
         txn->parent->roll_info.num_rollentries       += txn->roll_info.num_rollentries;
+        toku_txn_unlock(txn->parent);
     } else {
         r = apply_txn(txn, lsn, toku_commit_rollback_item);
         assert(r==0);


### PR DESCRIPTION
Fix a data race in the rollback log found when running hotindexer-bw test with the thread sanitizer.  The problem was caused when a indexer thread and a client thread were simultaneously updating the same transaction rollback log.  There was a case where the rollback log was not locked with the transaction lock, which caused the data race to be discovered.

This fix is one of several that I discussed with George Lorch.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.