### PR TITLE
Test and fix a minicron data race detected with the thread sanitizer.

### DIFF
--- a/util/minicron.cc
+++ b/util/minicron.cc
@@ -85,8 +85,9 @@ minicron_do (void *pv)
             toku_cond_wait(&p->condvar, &p->mutex);
         } 
         else if (p->period_in_ms <= 1000) {
+            uint32_t period_in_ms = p->period_in_ms;
             toku_mutex_unlock(&p->mutex);
-            usleep(p->period_in_ms * 1000);
+            usleep(period_in_ms * 1000);
             toku_mutex_lock(&p->mutex);
         }
         else {

--- a/util/tests/minicron-change-period-data-race.cc
+++ b/util/tests/minicron-change-period-data-race.cc
@@ -1,0 +1,66 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+This file is part of PerconaFT.
+
+
+Copyright (c) 2018, Percona and/or its affiliates. All rights reserved.
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+#ident "Copyright (c) 2018, Percona and/or its affiliates. All rights reserved."
+
+#include <toku_portability.h>
+#include "test.h"
+#include "util/minicron.h"
+#include <unistd.h>
+#include <string.h>
+#include <stdlib.h>
+
+// The thread sanitizer detected a data race in the minicron in a test unrelated to the minicron.
+// This test reproduces the data race in a much smaller test which merely runs minicron tasks
+// while changing the minicron period in an unrelated thread.
+
+static int do_nothing(void *UU(v)) {
+    return 0;
+}
+
+int test_main (int argc, const char *argv[]) {
+    default_parse_args(argc,argv);
+
+    minicron m = {};
+    int r = toku_minicron_setup(&m, 1, do_nothing, nullptr);
+    assert(r == 0);
+    for (int i=0; i<1000; i++) 
+        toku_minicron_change_period(&m, 1);
+    r = toku_minicron_shutdown(&m);
+    assert(r == 0);
+
+    return 0;
+}


### PR DESCRIPTION
A data race in the minicron between the 'do' and 'change period' functions was detected by the thread sanitizer.  The fix is trivial:  read the period while holding the minicron lock.  This pull request also includes a simple test case that exposes the data race when the code is compiled with the thread sanitizer.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.