### PR TITLE
Fix memory leaks in TDB-2 and TDB-89 tests

### DIFF
--- a/ft/tests/test-TDB2-pe.cc
+++ b/ft/tests/test-TDB2-pe.cc
@@ -91,6 +91,8 @@ static void doit() {
   r = toku_testsetup_leaf(ft, &node_leaf, 2, pivots, &pivot_len);
   assert(r == 0);
 
+  toku_free(pivots[0]);
+
   r = toku_testsetup_nonleaf(ft, 1, &node_internal, 1, &node_leaf, 0, 0);
   assert(r == 0);
 

--- a/ft/tests/test-TDB89.cc
+++ b/ft/tests/test-TDB89.cc
@@ -108,6 +108,8 @@ static void doit() {
   r = toku_testsetup_leaf(ft, &node_leaf, 2, pivots, &pivot_len);
   assert(r == 0);
 
+  toku_free(pivots[0]);
+
   r = toku_testsetup_nonleaf(ft, 1, &node_internal, 1, &node_leaf, 0, 0);
   assert(r == 0);
 


### PR DESCRIPTION
Two new tests with memory leaks cause valgrind failures.  Fix the TDB-2 and TDB-89 tests.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.