### PR TITLE
PS-3887: TokuDB does not compile with -DWITH_PERFSCHEMA_STORAGE_ENGIN…

### DIFF
--- a/portability/toku_instr_mysql.cc
+++ b/portability/toku_instr_mysql.cc
@@ -1,4 +1,4 @@
-#ifdef MYSQL_TOKUDB_ENGINE
+#ifdef TOKU_MYSQL_WITH_PFS
 #include "toku_portability.h"
 #include "toku_pthread.h"
 
@@ -362,4 +362,4 @@ void toku_instr_rwlock_unlock(toku_pthread_rwlock_t &rwlock) {
         PSI_RWLOCK_CALL(unlock_rwlock)(rwlock.psi_rwlock);
 }
 
-#endif  // MYSQL_TOKUDB_ENGINE
+#endif  // TOKU_MYSQL_WITH_PFS

--- a/portability/toku_instrumentation.h
+++ b/portability/toku_instrumentation.h
@@ -41,7 +41,7 @@ class toku_instr_probe_empty {
 
 extern toku_instr_key toku_uninstrumented;
 
-#ifndef MYSQL_TOKUDB_ENGINE
+#ifndef TOKU_MYSQL_WITH_PFS
 
 #include <pthread.h>
 
@@ -245,10 +245,10 @@ inline void toku_instr_rwlock_wrlock_wait_end(
 
 inline void toku_instr_rwlock_unlock(UU(toku_pthread_rwlock_t &rwlock)) {}
 
-#else  // MYSQL_TOKUDB_ENGINE
+#else  // TOKU_MYSQL_WITH_PFS
 // There can be not only mysql but also mongodb or any other PFS stuff
 #include <toku_instr_mysql.h>
-#endif  // MYSQL_TOKUDB_ENGINE
+#endif  // TOKU_MYSQL_WITH_PFS
 
 extern toku_instr_key toku_uninstrumented;
 


### PR DESCRIPTION
…E=OFF

Use TOKU_MYSQL_WITH_PFS instead of MYSQL_TOKUDB_ENGINE because there can be
the case when TokuDB engine is built without PFS. At the other hand
TOKU_MYSQL_WITH_PFS can not be defined without MYSQL_TOKUDB_ENGINE(see
CMakeLists.txt).

Based on Vlad work at:
https://github.com/vlad-lesin/percona-server/commit/203ed53e8318d431b66e6516a6616747d709be26
