### PR TITLE
[TDB-20] With checkpoint disabled, closing FT file still rotates header.

### DIFF
--- a/ft/cachetable/cachetable-internal.h
+++ b/ft/cachetable/cachetable-internal.h
@@ -161,6 +161,9 @@ struct cachefile {
     void (*end_checkpoint_userdata)(CACHEFILE cf, int fd, void *userdata); // after checkpointing cachefiles call this function.
     void (*note_pin_by_checkpoint)(CACHEFILE cf, void *userdata); // add a reference to the userdata to prevent it from being removed from memory
     void (*note_unpin_by_checkpoint)(CACHEFILE cf, void *userdata); // add a reference to the userdata to prevent it from being removed from memory
+
+    void (*note_pin_by_backup)(CACHEFILE cf, void *userdata); // add a reference to the userdata to prevent it from being removed from memory
+    void (*note_unpin_by_backup)(CACHEFILE cf, void *userdata); // add a reference to the userdata to prevent it from being removed from memory
     BACKGROUND_JOB_MANAGER bjm;
 };
 
@@ -413,6 +416,8 @@ public:
     void add_background_job();
     void remove_background_job();
     void end_checkpoint(void (*testcallback_f)(void*),  void* testextra);
+    void begin_backup();
+    void end_backup();
     TOKULOGGER get_logger();
     // used during begin_checkpoint
     void increment_num_txns();

--- a/ft/cachetable/cachetable.h
+++ b/ft/cachetable/cachetable.h
@@ -147,6 +147,8 @@ void toku_cachetable_begin_checkpoint (CHECKPOINTER cp, struct tokulogger *logge
 void toku_cachetable_end_checkpoint(CHECKPOINTER cp, struct tokulogger *logger, 
                                    void (*testcallback_f)(void*),  void * testextra);
 
+void toku_cachetable_begin_backup(CACHETABLE ct);
+void toku_cachetable_end_backup(CACHETABLE ct);
 
 // Shuts down checkpoint thread
 // Requires no locks be held that are taken by the checkpoint function
@@ -285,7 +287,9 @@ void toku_cachefile_set_userdata(CACHEFILE cf, void *userdata,
     void (*begin_checkpoint_userdata)(LSN, void*),
     void (*end_checkpoint_userdata)(CACHEFILE, int, void*),
     void (*note_pin_by_checkpoint)(CACHEFILE, void*),
-    void (*note_unpin_by_checkpoint)(CACHEFILE, void*));
+    void (*note_unpin_by_checkpoint)(CACHEFILE, void*),
+    void (*note_pin_by_backup)(CACHEFILE, void*),
+    void (*note_unpin_by_backup)(CACHEFILE, void*));
 // Effect: Store some cachefile-specific user data.  When the last reference to a cachefile is closed, we call close_userdata().
 // Before starting a checkpoint, we call checkpoint_prepare_userdata().
 // When the cachefile needs to be checkpointed, we call checkpoint_userdata().

--- a/ft/ft-internal.h
+++ b/ft/ft-internal.h
@@ -197,7 +197,9 @@ struct ft {
     uint32_t num_txns;
     // A checkpoint is running.  If true, then keep this header around for checkpoint, like a transaction
     bool pinned_by_checkpoint;
-
+    // Number of backups that are using this FT. If it is nonzero, keep this header around until backup
+    // is completd.
+    uint32_t num_backups;
     // is this ft a blackhole? if so, all messages are dropped.
     bool blackhole;
 

--- a/ft/tests/cachetable-pin-checkpoint.cc
+++ b/ft/tests/cachetable-pin-checkpoint.cc
@@ -358,21 +358,15 @@ cachetable_test (void) {
     toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
     const char *fname1 = TOKU_TEST_FILENAME;
     unlink(fname1);
-    r = toku_cachetable_openf(&f1, ct, fname1, O_RDWR|O_CREAT, S_IRWXU|S_IRWXG|S_IRWXO); assert(r == 0);
+    r = toku_cachetable_openf(&f1, ct, fname1, O_RDWR | O_CREAT,
+                              S_IRWXU | S_IRWXG | S_IRWXO);
+    assert(r == 0);
 
     toku_cachefile_set_userdata(
-        f1,
-        NULL,
-        &dummy_log_fassociate,
-        &dummy_close_usr,
-        &dummy_free_usr,
-        &dummy_chckpnt_usr,
-        &test_begin_checkpoint,
-        &dummy_end,
-        &dummy_note_pin,
-        &dummy_note_unpin
-        );
-    
+        f1, NULL, &dummy_log_fassociate, &dummy_close_usr, &dummy_free_usr,
+        &dummy_chckpnt_usr, &test_begin_checkpoint, &dummy_end, &dummy_note_pin,
+        &dummy_note_unpin, &dummy_note_pin, &dummy_note_unpin);
+
     toku_pthread_t time_tid;
     toku_pthread_t checkpoint_tid;
     toku_pthread_t move_tid[NUM_MOVER_THREADS];

--- a/ft/tests/cachetable-put-checkpoint.cc
+++ b/ft/tests/cachetable-put-checkpoint.cc
@@ -487,20 +487,16 @@ cachetable_test (void) {
     toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
     const char *fname1 = TOKU_TEST_FILENAME;
     unlink(fname1);
-    r = toku_cachetable_openf(&f1, ct, fname1, O_RDWR|O_CREAT, S_IRWXU|S_IRWXG|S_IRWXO); assert(r == 0);
+    r = toku_cachetable_openf(&f1, ct, fname1, O_RDWR | O_CREAT,
+                              S_IRWXU | S_IRWXG | S_IRWXO);
+    assert(r == 0);
 
     toku_cachefile_set_userdata(
-        f1,
-        NULL,
-        &dummy_log_fassociate,
-        &dummy_close_usr,
-        &dummy_free_usr,
+        f1, NULL, &dummy_log_fassociate, &dummy_close_usr, &dummy_free_usr,
         &dummy_chckpnt_usr,
         test_begin_checkpoint, // called in begin_checkpoint
-        &dummy_end,
-        &dummy_note_pin,
-        &dummy_note_unpin
-        );
+        &dummy_end, &dummy_note_pin, &dummy_note_unpin, &dummy_note_pin,
+        &dummy_note_unpin);
 
     toku_pthread_t time_tid;
     toku_pthread_t checkpoint_tid;

--- a/ft/tests/cachetable-simple-close.cc
+++ b/ft/tests/cachetable-simple-close.cc
@@ -50,18 +50,10 @@ static void free_usr(CACHEFILE UU(cf), void* UU(p)) {
 }
 
 static void set_cf_userdata(CACHEFILE f1) {
-    toku_cachefile_set_userdata(
-        f1,
-        NULL,
-        &dummy_log_fassociate,
-        &close_usr,
-        &free_usr,
-        &dummy_chckpnt_usr,
-        &dummy_begin,
-        &dummy_end,
-        &dummy_note_pin,
-        &dummy_note_unpin
-        );
+  toku_cachefile_set_userdata(f1, NULL, &dummy_log_fassociate, &close_usr,
+                              &free_usr, &dummy_chckpnt_usr, &dummy_begin,
+                              &dummy_end, &dummy_note_pin, &dummy_note_unpin,
+                              &dummy_note_pin, &dummy_note_unpin);
 }
 
 bool keep_me;

--- a/ft/tests/cachetable-test.h
+++ b/ft/tests/cachetable-test.h
@@ -58,15 +58,9 @@ static void dummy_note_unpin(CACHEFILE UU(cf), void* UU(p)) { }
 static UU() void
 create_dummy_functions(CACHEFILE cf)
 {
-    void *ud = NULL;
-    toku_cachefile_set_userdata(cf,
-                               ud,
-                               &dummy_log_fassociate,
-                               &dummy_close_usr,
-                               &dummy_free_usr,
-                               &dummy_chckpnt_usr,
-                               &dummy_begin,
-                               &dummy_end,
-                               &dummy_note_pin,
-                               &dummy_note_unpin);
+  void *ud = NULL;
+  toku_cachefile_set_userdata(cf, ud, &dummy_log_fassociate, &dummy_close_usr,
+                              &dummy_free_usr, &dummy_chckpnt_usr, &dummy_begin,
+                              &dummy_end, &dummy_note_pin, &dummy_note_unpin,
+                              &dummy_note_pin, &dummy_note_unpin);
 };

--- a/ft/tests/fifo-test.cc
+++ b/ft/tests/fifo-test.cc
@@ -73,15 +73,17 @@ test_enqueue(int n) {
         if (i == 0) {
             xids = toku_xids_get_root_xids();
         } else {
-            int r = toku_xids_create_child(toku_xids_get_root_xids(), &xids, (TXNID)i);
-            assert_zero(r);
+          int r = toku_xids_create_child(toku_xids_get_root_xids(), &xids,
+                                         (TXNID)i);
+          assert_zero(r);
         }
         MSN msn = next_dummymsn();
         if (startmsn.msn == ZERO_MSN.msn)
-            startmsn = msn;
-        enum ft_msg_type type = (enum ft_msg_type) i;
+          startmsn = msn;
+        enum ft_msg_type type = (enum ft_msg_type)i;
         DBT k, v;
-        ft_msg msg(toku_fill_dbt(&k, thekey, thekeylen), toku_fill_dbt(&v, theval, thevallen), type, msn, xids);
+        ft_msg msg(toku_fill_dbt(&k, thekey, thekeylen),
+                   toku_fill_dbt(&v, theval, thevallen), type, msn, xids);
         msg_buffer.enqueue(msg, true, nullptr);
         toku_xids_destroy(&xids);
         toku_free(thekey);

--- a/ft/tests/ft-in-backup-test.cc
+++ b/ft/tests/ft-in-backup-test.cc
@@ -1,0 +1,176 @@
+/* -*- mode: C++; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+// vim: ft=cpp:expandtab:ts=8:sw=4:softtabstop=4:
+#ident "$Id$"
+/*======
+This file is part of PerconaFT.
+
+
+Copyright (c) 2006, 2017, Percona and/or its affiliates. All rights reserved.
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License, version 2,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+
+----------------------------------------
+
+    PerconaFT is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License, version 3,
+    as published by the Free Software Foundation.
+
+    PerconaFT is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with PerconaFT.  If not, see <http://www.gnu.org/licenses/>.
+======= */
+
+#ident                                                                         \
+    "Copyright (c) 2006, 2017, Percona and/or its affiliates. All rights reserved."
+
+#include "cachetable/checkpoint.h"
+#include "test.h"
+
+static TOKUTXN const null_txn = 0;
+static const char *fname = TOKU_TEST_FILENAME;
+
+/* test for_backup in ft_close */
+static void test_in_backup() {
+  int r;
+  CACHETABLE ct;
+  FT_HANDLE ft;
+  unlink(fname);
+
+  toku_cachetable_create(&ct, 0, ZERO_LSN, nullptr);
+  // TEST1 : normal case without backup
+  r = toku_open_ft_handle(fname, 1, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  {
+    DBT k, v;
+    toku_ft_insert(ft, toku_fill_dbt(&k, "hello", 6),
+                   toku_fill_dbt(&v, "there", 6), null_txn);
+  }
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  ft_lookup_and_check_nodup(ft, "hello", "there");
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+  toku_cachetable_close(&ct);
+
+  // TEST2: new insert in the middle of a backup before backup finishes
+  // should be invisible
+  toku_cachetable_create(&ct, 0, ZERO_LSN, nullptr);
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+
+  toku_cachetable_begin_backup(ct);
+  // this key/value is still in fly since we are in the middle of a back up
+  {
+    DBT k, v;
+    toku_ft_insert(ft, toku_fill_dbt(&k, "halou", 6),
+                   toku_fill_dbt(&v, "not there", 10), null_txn);
+  }
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  ft_lookup_and_check_nodup(ft, "halou", "not there");
+
+  // because we are in backup, so the FT header is stale after
+  // cachefile & cachetable closed.
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+  toku_cachetable_close(&ct);
+
+  // check the in fly key/value, it shouldn't exist
+  toku_cachetable_create(&ct, 0, ZERO_LSN, nullptr);
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  ft_lookup_and_fail_nodup(ft, (char *)"halou");
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+  // the backup ends here.
+  toku_cachetable_end_backup(ct);
+  toku_cachetable_close(&ct);
+
+  // TEST3: new insert in the middle of a backup should become visible
+  // once the backup completes. There is no ft leak here as once the
+  // backup completes the ft ref drops to zero and gets evicted.
+  toku_cachetable_create(&ct, 0, ZERO_LSN, nullptr);
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+
+  toku_cachetable_begin_backup(ct);
+  // this key/value is still in fly since we are in the middle of a backup
+  {
+    DBT k, v;
+    toku_ft_insert(ft, toku_fill_dbt(&k, "halou1", 7),
+                   toku_fill_dbt(&v, "not there", 10), null_txn);
+  }
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  ft_lookup_and_check_nodup(ft, "halou1", "not there");
+
+  // because we are in backup, so the FT header is stale after
+  // cachefile & cachetable closed
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+  // but this time we ends the backup here before checking the new insert.
+  toku_cachetable_end_backup(ct);
+  toku_cachetable_close(&ct);
+
+  toku_cachetable_create(&ct, 0, ZERO_LSN, nullptr);
+  r = toku_open_ft_handle(fname, 0, &ft, 1 << 12, 1 << 9,
+                          TOKU_DEFAULT_COMPRESSION_METHOD, ct, null_txn,
+                          toku_builtin_compare_fun);
+  assert_zero(r);
+  ft_lookup_and_check_nodup(ft, "halou1", "not there");
+  r = toku_close_ft_handle_nolsn(ft, 0);
+  assert_zero(r);
+  toku_cachetable_close(&ct);
+}
+
+int test_main(int argc, const char *argv[]) {
+  default_parse_args(argc, argv);
+  test_in_backup();
+  if (verbose)
+    printf("test ok\n");
+  return 0;
+}

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -1868,7 +1868,10 @@ env_checkpointing_postpone(DB_ENV * env) {
     HANDLE_PANICKED_ENV(env);
     int r = 0;
     if (!env_opened(env)) r = EINVAL;
-    else toku_checkpoint_safe_client_lock();
+    else {
+        toku_checkpoint_safe_client_lock();
+        toku_cachetable_begin_backup(env->i->cachetable);
+    }
     return r;
 }
 
@@ -1877,7 +1880,10 @@ env_checkpointing_resume(DB_ENV * env) {
     HANDLE_PANICKED_ENV(env);
     int r = 0;
     if (!env_opened(env)) r = EINVAL;
-    else toku_checkpoint_safe_client_unlock();
+    else {
+        toku_cachetable_end_backup(env->i->cachetable);
+        toku_checkpoint_safe_client_unlock();
+    }
     return r;
 }
 


### PR DESCRIPTION
jenkin: https://jenkins.percona.com/view/TokuDB/job/PerconaFT-param/120/
         [Updated the comments and formats from the last PR.]

         This is an attempt based on @BohuTang's patch
             https://github.com/percona/PerconaFT/pull/331

         in particular, the ctest mostly comes from his with minor updates.

         Summary:
             1) The issue is real.
             2) @Bohu's patch works for mediating the issue but somewhat introduces
                a ft leak that the ft with ref=0 may be left until next open/close or
                checkpoint.
             3) If ft_close should be held off upon a backup, then it simply means
                a backup should hold a ref to the ft and responsible for closing ft up
                if it is the last one to hold it, like any other possible referencer.
                including the checkpoint, the txn and ft handlers.
             4) mtr test contributed by @BohuTang still passes. (in a different PS PR).