### PR TITLE
PS-3950: gcc-8 compilation warnings

### DIFF
--- a/portability/memory.h
+++ b/portability/memory.h
@@ -107,7 +107,7 @@ size_t toku_malloc_usable_size(void *p) __attribute__((__visibility__("default")
 #define XMALLOC(v) CAST_FROM_VOIDP(v, toku_xmalloc(sizeof(*v)))
 #define XMALLOC_N(n,v) CAST_FROM_VOIDP(v, toku_xmalloc((n)*sizeof(*v)))
 #define XCALLOC_N(n,v) CAST_FROM_VOIDP(v, toku_xcalloc((n), (sizeof(*v))))
-#define XCALLOC(v) XCALLOC_N(1,(v))
+#define XCALLOC(v) XCALLOC_N(1,v)
 #define XREALLOC(v,s) CAST_FROM_VOIDP(v, toku_xrealloc(v, s))
 #define XREALLOC_N(n,v) CAST_FROM_VOIDP(v, toku_xrealloc(v, (n)*sizeof(*v)))
 

--- a/util/dmt.cc
+++ b/util/dmt.cc
@@ -80,8 +80,8 @@ void dmt<dmtdata_t, dmtdataout_t, dmtwriter_t>::create_from_sorted_memory_of_fix
         paranoid_invariant(numvalues > 0);
         void *ptr = toku_mempool_malloc(&this->mp, aligned_memsize);
         paranoid_invariant_notnull(ptr);
-        uint8_t * const CAST_FROM_VOIDP(dest, ptr);
-        const uint8_t * const CAST_FROM_VOIDP(src, mem);
+        uint8_t * const dest = static_cast<uint8_t *>(ptr);
+        const uint8_t * const src = static_cast<const uint8_t *>(mem);
         if (pad_bytes == 0) {
             paranoid_invariant(aligned_memsize == mem_length);
             memcpy(dest, src, aligned_memsize);


### PR DESCRIPTION
Fix the following warnings:
- type qualifiers ignored on cast result type [-Werror=ignored-qualifiers]
- unnecessary parentheses in declaration of ‘eresult’ [-Werror=parentheses]