### PR TITLE
the cachetable-simple-pin-nonblocking-cheap test occasionally fails due to a locking conflict with the cachetable evictor.

### DIFF
--- a/ft/tests/cachetable-simple-pin-nonblocking-cheap.cc
+++ b/ft/tests/cachetable-simple-pin-nonblocking-cheap.cc
@@ -107,7 +107,11 @@ run_case_that_should_fail(CACHEFILE f1, pair_lock_type first_lock, pair_lock_typ
 
 static void
 run_test (void) {
-    const int test_limit = 12;
+    // sometimes the cachetable evictor runs during the test.  this sometimes causes cachetable pair locking contention,
+    // which results with a TOKUDB_TRY_AGAIN error occurring.  unfortunately, the test does not expect this and fails.
+    // set cachetable size limit to a value big enough so that the cachetable evictor is not triggered during the test.
+    const int test_limit = 100;
+
     int r;
     CACHETABLE ct;
     toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);


### PR DESCRIPTION
The cachetable-simple-pin-noblocking-cheap test occasionally fails due to a TOKUDB_TRY_AGAIN error being kicked out of the cachetable to the test.  The test does not expect this error so it crashes.  The TOKUDB_TRY_AGAIN error was caused by a locking conflict between the test and the cachetable evictor which periodically runs on a background thread.  Since the evictor is not an important part of this test, its execution was removed by setting the cachetable size larger than the test's cachetable footprint.

Tools:
Ubuntu 18.04
gcc 7.3.0
Cmake 3.10.2

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.