### PR TITLE
PS-4711: crash on TokuDB PFS-instrumented mutexes deinitialization

### DIFF
--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -185,9 +185,12 @@ toku_ydb_init(void) {
 // Do not clean up resources if env is panicked, just exit ugly
 void 
 toku_ydb_destroy(void) {
+    if (!ydb_layer_status.initialized)
+        return;
     if (env_is_panicked == 0) {
         toku_ft_layer_destroy();
     }
+    ydb_layer_status.initialized = false;
 }
 
 static int


### PR DESCRIPTION
shutdown_performance_schema() is always invoked before exit(), what means
global mutexes are always destroyed after perfomance schema shutdown, what
causes SIGFAULT on some platforms(debian wheeze in particular).

For PerconaFT layer the fix is in invoking ydb-layer deinitialization function
explicitly from storage engine shutdown function. But the same function is also
invoked on library unload, see libtokuft_destroy(). The certain flag is used to
avoid invoking ydb-layer deinitialization function twice.

Testing: 
https://jenkins.percona.com/view/5.7/job/mysql-5.7-param/1891/

See also: https://github.com/percona/percona-server/pull/2479