### PR TITLE
PS-4381 : PerconaFT needs different libraries to link to 8.0 debug sy…

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -15,7 +15,7 @@ foreach(tool ${tools})
     if ((CMAKE_BUILD_TYPE MATCHES "Debug") AND
         (CMAKE_CXX_FLAGS_DEBUG MATCHES " -DENABLED_DEBUG_SYNC"))
       if (MYSQL_BASE_VERSION VERSION_EQUAL "8.0")
-        target_link_libraries(${tool} sql_main sql_gis sql_main binlog rpl master slave ${ICU_LIBRARIES})
+        target_link_libraries(${tool} sql_main sql_gis sql_main sql_dd sql_gis binlog rpl master slave ${ICU_LIBRARIES})
       else ()
         target_link_libraries(${tool} sql binlog rpl master slave)
       endif ()


### PR DESCRIPTION
…nc and PFS

- Fixed another new split out of libs with strange cross dependencies that for
  some unknown reason causes problems with linkage of supporting tools that are
  only used within the ct used within the cest suite.est suite.