### PR TITLE
fix tests to compile with gcc 8.2.0

### DIFF
--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -108,6 +108,7 @@ set_cflags_if_supported(
   -fno-rtti
   -fno-exceptions
   -Wno-error=nonnull-compare
+  -Wno-error=parentheses
   )
 ## set_cflags_if_supported_named("-Weffc++" -Weffcpp)
 

--- a/ft/tests/cachetable-simple-close.cc
+++ b/ft/tests/cachetable-simple-close.cc
@@ -38,6 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "test.h"
 #include "cachetable-test.h"
+#include <string>
 
 bool close_called;
 bool free_called;
@@ -193,15 +194,15 @@ static void test_multiple_cachefiles(bool use_same_hash) {
         CACHETABLE ct;
         toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
 
-        char fname1[strlen(TOKU_TEST_FILENAME) + sizeof("_1")];    
-        strcpy(fname1, TOKU_TEST_FILENAME);
-        strncat(fname1, "_1", sizeof("_1"));
-        char fname2[strlen(TOKU_TEST_FILENAME) + sizeof("_2")];    
-        strcpy(fname2, TOKU_TEST_FILENAME);
-        strncat(fname2, "_2", sizeof("_2"));
-        char fname3[strlen(TOKU_TEST_FILENAME) + sizeof("_3")];    
-        strcpy(fname3, TOKU_TEST_FILENAME);
-        strncat(fname3, "_3", sizeof("_3"));
+        std::string fname1s(TOKU_TEST_FILENAME);
+        fname1s.append("_1");
+        const char *fname1 = fname1s.c_str();
+        std::string fname2s(TOKU_TEST_FILENAME);
+        fname2s.append("_2");
+        const char *fname2 = fname2s.c_str();
+        std::string fname3s(TOKU_TEST_FILENAME);
+        fname3s.append("_3");
+        const char *fname3 = fname3s.c_str();
 
         unlink(fname1);
         unlink(fname2);
@@ -242,7 +243,7 @@ static void test_multiple_cachefiles(bool use_same_hash) {
         toku_cachefile_close(&f2, false, ZERO_LSN);
         toku_cachefile_close(&f3, false, ZERO_LSN);
 
-        char* fname_to_open = NULL;
+        const char* fname_to_open = NULL;
         if (iter == 0) {
             fname_to_open  = fname1;
         }
@@ -278,12 +279,12 @@ static void test_evictor(void) {
     CACHETABLE ct;
     toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
 
-    char fname1[strlen(TOKU_TEST_FILENAME) + sizeof("_1")];    
-    strcpy(fname1, TOKU_TEST_FILENAME);
-    strncat(fname1, "_1", sizeof("_1"));
-    char fname2[strlen(TOKU_TEST_FILENAME) + sizeof("_2")];    
-    strcpy(fname2, TOKU_TEST_FILENAME);
-    strncat(fname2, "_2", sizeof("_2"));
+    std::string fname1s(TOKU_TEST_FILENAME);
+    fname1s.append("_1");
+    const char *fname1 = fname1s.c_str();
+    std::string fname2s(TOKU_TEST_FILENAME);
+    fname2s.append("_2");
+    const char *fname2 = fname2s.c_str();
 
     unlink(fname1);
     unlink(fname2);

--- a/locktree/tests/lock_request_start_retry_race.cc
+++ b/locktree/tests/lock_request_start_retry_race.cc
@@ -83,7 +83,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)

--- a/locktree/tests/lock_request_start_retry_race_3.cc
+++ b/locktree/tests/lock_request_start_retry_race_3.cc
@@ -96,7 +96,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)

--- a/locktree/tests/lock_request_start_retry_wait_race_2.cc
+++ b/locktree/tests/lock_request_start_retry_wait_race_2.cc
@@ -98,7 +98,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)


### PR DESCRIPTION
Some tests @ 5fa6f64 do not compile with gcc 8.2.0 on ubuntu 18.10.  Get these tests to compile and run.

Copyright (c) 2018, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.