### PR TITLE
PS-5406 - jemalloc 5.0.x causes TokuDB/PerconaFT to assert on load

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -4973,6 +4973,7 @@ int toku_ft_layer_init(void) {
 
     // Portability must be initialized first
     r = toku_portability_init();
+    assert(r==0);
     if (r) {
         goto exit;
     }
@@ -4980,6 +4981,7 @@ int toku_ft_layer_init(void) {
     toku_pfs_keys_init("fti");
 
     r = db_env_set_toku_product_name("tokudb");
+    assert(r==0);
     if (r) {
         goto exit;
     }

--- a/portability/portability.cc
+++ b/portability/portability.cc
@@ -85,9 +85,11 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 int
 toku_portability_init(void) {
     int r = toku_memory_startup();
+    assert(r==0);
     if (r == 0) {
         uint64_t hz;
         r = toku_os_get_processor_frequency(&hz); // get and cache freq
+        assert(r==0);
     }
     (void) toku_os_get_pagesize(); // get and cache pagesize
     return r;


### PR DESCRIPTION
- jemalloc mallctl_f("opt.lg_chunk", ...) is failing in memory init with
  jemalloc 5.1.0.  This option was removed in 5.0.0 and versions of jemalloc
  greater than 5.0 no longer operate with the concept of lg_chunk.  There is no
  equivalent replacement functionality.  For this specific issue, lg_chunk is
  used by PerconaFT to set the threshold where allocations will switch to using
  mmap instead of the standard allocator.  It is reasonable to recognize the
  lg_chunk query failure and pick a rational value and continue on rather than
  failing and asserting.  For the older jemalloc versions, this value was 4MB
  by default.

- Fixed missing initialization of global flag indicating memory startup status.

- Added more assertions in the startup path to catch specific issues.

- Altered behavior of jemalloc startup to recognize when lg_chunk is not
  supported and use 4MB instead.