### PR TITLE
PS-5102 : Merge MySQL 8.0.16

### DIFF
--- a/portability/CMakeLists.txt
+++ b/portability/CMakeLists.txt
@@ -18,14 +18,13 @@ add_library(${LIBTOKUPORTABILITY} SHARED ${tokuportability_srcs})
 target_link_libraries(${LIBTOKUPORTABILITY} LINK_PRIVATE ${LIBJEMALLOC})
 target_link_libraries(${LIBTOKUPORTABILITY} LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
 
-add_library(tokuportability_static_conv STATIC ${tokuportability_srcs})
-set_target_properties(tokuportability_static_conv PROPERTIES POSITION_INDEPENDENT_CODE ON)
-add_dependencies(tokuportability_static_conv build_jemalloc)
-set(tokuportability_source_libs tokuportability_static_conv ${LIBJEMALLOC} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
-toku_merge_static_libs(${LIBTOKUPORTABILITY}_static ${LIBTOKUPORTABILITY}_static "${tokuportability_source_libs}")
+add_library(${LIBTOKUPORTABILITY}_static STATIC ${tokuportability_srcs})
+#add_dependencies(${LIBTOKUPORTABILITY}_static build_jemalloc)
+target_link_libraries(${LIBTOKUPORTABILITY}_static LINK_PUBLIC ${LIBJEMALLOC} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
+maybe_add_gcov_to_libraries(${LIBTOKUPORTABILITY} ${LIBTOKUPORTABILITY}_static)
+set_property(TARGET ${LIBTOKUPORTABILITY} ${LIBTOKUPORTABILITY}_static APPEND PROPERTY COMPILE_DEFINITIONS _GNU_SOURCE)
+set_target_properties(${LIBTOKUPORTABILITY}_static PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
-maybe_add_gcov_to_libraries(${LIBTOKUPORTABILITY} tokuportability_static_conv)
-set_property(TARGET ${LIBTOKUPORTABILITY} tokuportability_static_conv APPEND PROPERTY COMPILE_DEFINITIONS _GNU_SOURCE)
 
 set_property(SOURCE file memory os_malloc portability toku_assert toku_rwlock APPEND PROPERTY
   COMPILE_DEFINITIONS TOKU_ALLOW_DEPRECATED=1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,15 +22,13 @@ target_link_libraries(${LIBTOKUDB} LINK_PRIVATE locktree_static ft_static util_s
 target_link_libraries(${LIBTOKUDB} LINK_PUBLIC z)
 
 ## make the static library
-add_library(tokudb_static_conv STATIC ${tokudb_srcs})
-add_dependencies(tokudb_static_conv install_tdb_h generate_log_code)
-set_target_properties(tokudb_static_conv PROPERTIES POSITION_INDEPENDENT_CODE ON)
-set(tokudb_source_libs tokudb_static_conv locktree_static ft_static util_static lzma snappy)
-toku_merge_static_libs(${LIBTOKUDB}_static ${LIBTOKUDB}_static "${tokudb_source_libs}")
+add_library(${LIBTOKUDB}_static STATIC ${tokudb_srcs})
+add_dependencies(${LIBTOKUDB}_static install_tdb_h generate_log_code)
+target_link_libraries(${LIBTOKUDB}_static locktree_static ft_static util_static lzma snappy)
 
 ## add gcov and define _GNU_SOURCE
-maybe_add_gcov_to_libraries(${LIBTOKUDB} tokudb_static_conv)
-set_property(TARGET ${LIBTOKUDB} tokudb_static_conv APPEND PROPERTY COMPILE_DEFINITIONS _GNU_SOURCE)
+maybe_add_gcov_to_libraries(${LIBTOKUDB} ${LIBTOKUDB}_static)
+set_property(TARGET ${LIBTOKUDB} ${LIBTOKUDB}_static APPEND PROPERTY COMPILE_DEFINITIONS _GNU_SOURCE)
 
 ## add a version script and set -fvisibility=hidden for the shared library
 configure_file(export.map . COPYONLY)


### PR DESCRIPTION
- Fixed cmake error:
  CMake Error at storage/tokudb/PerconaFT/cmake_modules/TokuMergeLibs.cmake:10 (GET_TARGET_PROPERTY):
    get_target_property() called with non-existent target "-lpthread".
  Call Stack (most recent call first):
    storage/tokudb/PerconaFT/cmake_modules/TokuMergeLibs.cmake:38 (TOKU_GET_DEPENDEND_OS_LIBS)
    storage/tokudb/PerconaFT/portability/CMakeLists.txt:25 (toku_merge_static_libs)

- Fixed cmake error:
  CMake Error at storage/tokudb/PerconaFT/cmake_modules/TokuMergeLibs.cmake:10 (GET_TARGET_PROPERTY):
    get_target_property() called with non-existent target "-lpthread".
  Call Stack (most recent call first):
    storage/tokudb/PerconaFT/cmake_modules/TokuMergeLibs.cmake:38 (TOKU_GET_DEPENDEND_OS_LIBS)
    storage/tokudb/PerconaFT/src/CMakeLists.txt:29 (toku_merge_static_libs)