### PR TITLE
PS-5102: Fix configuration error with MySQL 8.0.16

### DIFF
--- a/cmake_modules/TokuMergeLibs.cmake
+++ b/cmake_modules/TokuMergeLibs.cmake
@@ -6,7 +6,7 @@ FUNCTION(TOKU_GET_DEPENDEND_OS_LIBS target result)
   IF(deps)
    FOREACH(lib ${deps})
     # Filter out keywords for used for debug vs optimized builds
-    IF(NOT lib MATCHES "general" AND NOT lib MATCHES "debug" AND NOT lib MATCHES "optimized")
+    IF(TARGET ${lib})
       GET_TARGET_PROPERTY(lib_location ${lib} LOCATION)
       IF(NOT lib_location)
         SET(ret ${ret} ${lib})


### PR DESCRIPTION
"-lpthread" is passed as a dependency to to library merge functions,
causing a CMake error because of a non existent target. This patch
excludes any external library starting with "-l" from these checks.