### PR TITLE
PS-5102: Remove old build_jemalloc target

### DIFF
--- a/cmake_modules/TokuThirdParty.cmake
+++ b/cmake_modules/TokuThirdParty.cmake
@@ -1,39 +1,5 @@
 include(ExternalProject)
 
-if (NOT DEFINED LIBJEMALLOC)
-    ## add jemalloc with an external project
-    set(JEMALLOC_SOURCE_DIR "${TokuDB_SOURCE_DIR}/third_party/jemalloc" CACHE FILEPATH "Where to find jemalloc sources.")
-    if (EXISTS "${JEMALLOC_SOURCE_DIR}/configure")
-        set(jemalloc_configure_opts "CC=${CMAKE_C_COMPILER}" "--with-jemalloc-prefix=" "--with-private-namespace=tokudb_jemalloc_internal_" "--enable-cc-silence")
-        option(JEMALLOC_DEBUG "Build jemalloc with --enable-debug." OFF)
-        if (JEMALLOC_DEBUG)
-            list(APPEND jemalloc_configure_opts --enable-debug)
-        endif ()
-        ExternalProject_Add(build_jemalloc
-            PREFIX jemalloc
-            SOURCE_DIR "${JEMALLOC_SOURCE_DIR}"
-            CONFIGURE_COMMAND
-                "${JEMALLOC_SOURCE_DIR}/configure" ${jemalloc_configure_opts}
-                "--prefix=${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/jemalloc"
-        )
-
-        add_library(jemalloc STATIC IMPORTED GLOBAL)
-        set_target_properties(jemalloc PROPERTIES IMPORTED_LOCATION
-            "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/jemalloc/lib/libjemalloc_pic.a")
-        add_dependencies(jemalloc build_jemalloc)
-        add_library(jemalloc_nopic STATIC IMPORTED GLOBAL)
-        set_target_properties(jemalloc_nopic PROPERTIES IMPORTED_LOCATION
-            "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/jemalloc/lib/libjemalloc.a")
-        add_dependencies(jemalloc_nopic build_jemalloc)
-
-        # detect when we are being built as a subproject
-        if (NOT DEFINED MYSQL_PROJECT_NAME_DOCSTRING)
-            install(DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_CFG_INTDIR}/jemalloc/lib" DESTINATION .
-                COMPONENT tokukv_libs_extra)
-        endif ()
-    endif ()
-endif ()
-
 ## add lzma with an external project
 set(xz_configure_opts --with-pic --enable-static)
 if (APPLE)

--- a/portability/CMakeLists.txt
+++ b/portability/CMakeLists.txt
@@ -20,7 +20,6 @@ target_link_libraries(${LIBTOKUPORTABILITY} LINK_PUBLIC ${CMAKE_THREAD_LIBS_INIT
 
 add_library(tokuportability_static_conv STATIC ${tokuportability_srcs})
 set_target_properties(tokuportability_static_conv PROPERTIES POSITION_INDEPENDENT_CODE ON)
-add_dependencies(tokuportability_static_conv build_jemalloc)
 set(tokuportability_source_libs tokuportability_static_conv ${LIBJEMALLOC} ${CMAKE_THREAD_LIBS_INIT} ${EXTRA_SYSTEM_LIBS})
 toku_merge_static_libs(${LIBTOKUPORTABILITY}_static ${LIBTOKUPORTABILITY}_static "${tokuportability_source_libs}")
 

--- a/scripts/run-nightly-coverage-tests.bash
+++ b/scripts/run-nightly-coverage-tests.bash
@@ -26,7 +26,7 @@ if [ ! -d build ] ; then
         -D RUN_LONG_TESTS=ON \
         -D TOKUDB_DATA=$tokudbdir/../tokudb.data \
         ..
-    ninja build_jemalloc build_lzma build_snappy
+    ninja build_lzma build_snappy
     popd
 fi
 

--- a/scripts/run-nightly-drd-tests.bash
+++ b/scripts/run-nightly-drd-tests.bash
@@ -25,7 +25,7 @@ if [ ! -d build ] ; then
         -D RUN_LONG_TESTS=ON \
         -D TOKUDB_DATA=$tokudbdir/../tokudb.data \
         ..
-    ninja build_jemalloc build_lzma build_snappy
+    ninja build_lzma build_snappy
     popd
 fi
 

--- a/scripts/run-nightly-release-tests.bash
+++ b/scripts/run-nightly-release-tests.bash
@@ -25,7 +25,7 @@ if [ ! -d build ] ; then
         -D RUN_LONG_TESTS=ON \
         -D TOKUDB_DATA=$tokudbdir/../tokudb.data \
         ..
-    ninja build_jemalloc build_lzma build_snappy
+    ninja build_lzma build_snappy
     popd
 fi
 


### PR DESCRIPTION
Current cmake and build scripts refer to a "build_jemalloc" target,
which was never actually present in the git tree. Starting with
8.0.16, MySQL CMake scripts set CMP00046 to NEW, which emits errors
on non existing dependencies: the scripts work as before, and omit
a working makefile, but cmake reports an exit code of 1 in the end,
causing jenkins failures.

This change removes every mention of the build_jemalloc target,
fixing the issue.