### PR TITLE
PS-5932: Fix double initialization in ft tools

### DIFF
--- a/ft/ft-ops.cc
+++ b/ft/ft-ops.cc
@@ -4969,6 +4969,14 @@ static void toku_pfs_keys_destroy(void) {
 }
 
 int toku_ft_layer_init(void) {
+    static bool ft_layer_init_started = false;
+
+    if(ft_layer_init_started) {
+        return 0;
+    }
+
+    ft_layer_init_started = true;
+
     int r = 0;
 
     // Portability must be initialized first
@@ -4999,6 +5007,14 @@ exit:
 }
 
 void toku_ft_layer_destroy(void) {
+    static bool ft_layer_destroy_started = false;
+
+    if(ft_layer_destroy_started) {
+        return;
+    }
+
+    ft_layer_destroy_started = true;
+
     toku_mutex_destroy(&ft_open_close_lock);
     toku_ft_serialize_layer_destroy();
     toku_checkpoint_destroy();


### PR DESCRIPTION
The FT layer is initialized in toku_ft_layer_init, which is
normally called in ydb_lib.cc as part of the DLL initialization
process.

For some reason, the linker previously optimized these construction
functions out in tools, and manual initialization calls were added.

In the original PS-5932 pull request, a global variable was added
to ydb.cc, which changed the linker beheavior: it no longer
optimized out the dll initialization function. This resulted in
double initialization in tools, asserting in debug builds.

Fix: as tokudb uses C++11 on all platforms, a static bool variable
is added as a guards around toku_ft_layer_init and _destroy:
the functions can be safely called multiple times now.