### PR TITLE
PS-5674: Fixed compilation error caused by #warning in sys/sysctrl.h

### DIFF
--- a/portability/portability.cc
+++ b/portability/portability.cc
@@ -60,7 +60,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #if defined(HAVE_SYS_SYSCALL_H)
 # include <sys/syscall.h>
 #endif
-#if defined(HAVE_SYS_SYSCTL_H)
+#if defined(HAVE_SYS_SYSCTL_H) && !defined(_SC_PHYS_PAGES)
 # include <sys/sysctl.h>
 #endif
 #if defined(HAVE_PTHREAD_NP_H)


### PR DESCRIPTION
#warning directive was added to sys/sysctl.h in glibc>=2.30.
It is enough to disable it for PerconaFT/portability.
third_party/xz references above header as well, but in unused xz (not compiled) part (we compile only liblzma)