### PR TITLE
Fix memory leaks of pfs keys

### DIFF
--- a/cmake_modules/TokuSetupCTest.cmake
+++ b/cmake_modules/TokuSetupCTest.cmake
@@ -128,7 +128,7 @@ if (BUILD_TESTING OR BUILD_FT_TESTS OR BUILD_SRC_TESTS)
   endmacro(add_toku_test)
 
   ## setup a function to write tests that will run with helgrind
-  set(CMAKE_HELGRIND_COMMAND_STRING "valgrind --quiet --tool=helgrind --error-exitcode=1 --soname-synonyms=somalloc=*tokuportability* --suppressions=${TokuDB_SOURCE_DIR}/src/tests/helgrind.suppressions --trace-children=yes --trace-children-skip=sh,*/sh,basename,*/basename,dirname,*/dirname,rm,*/rm,cp,*/cp,mv,*/mv,cat,*/cat,diff,*/diff,grep,*/grep,date,*/date,test,*/tokudb_dump* --trace-children-skip-by-arg=--only_create,--test,--no-shutdown,novalgrind")
+  set(CMAKE_HELGRIND_COMMAND_STRING "valgrind --quiet --tool=helgrind --error-exitcode=1 --soname-synonyms=somalloc=*tokuportability* --suppressions=${TokuDB_SOURCE_DIR}/src/tests/helgrind.suppressions --trace-children=yes --trace-children-skip=sh,*/sh,basename,*/basename,dirname,*/dirname,rm,*/rm,cp,*/cp,mv,*/mv,cat,*/cat,diff,*/diff,grep,*/grep,date,*/date,test,*/tokudb_dump* --trace-children-skip-by-arg=--only_create,--test,--no-shutdown,novalgrind --fair-sched=try")
   function(add_helgrind_test pfx name)
     separate_arguments(CMAKE_HELGRIND_COMMAND_STRING)
     add_test(
@@ -139,7 +139,7 @@ if (BUILD_TESTING OR BUILD_FT_TESTS OR BUILD_SRC_TESTS)
   endfunction(add_helgrind_test)
 
   ## setup a function to write tests that will run with drd
-  set(CMAKE_DRD_COMMAND_STRING "valgrind --quiet --tool=drd --error-exitcode=1 --soname-synonyms=somalloc=*tokuportability* --suppressions=${TokuDB_SOURCE_DIR}/src/tests/drd.suppressions --trace-children=yes --trace-children-skip=sh,*/sh,basename,*/basename,dirname,*/dirname,rm,*/rm,cp,*/cp,mv,*/mv,cat,*/cat,diff,*/diff,grep,*/grep,date,*/date,test,*/tokudb_dump* --trace-children-skip-by-arg=--only_create,--test,--no-shutdown,novalgrind")
+  set(CMAKE_DRD_COMMAND_STRING "valgrind --quiet --tool=drd --error-exitcode=1 --soname-synonyms=somalloc=*tokuportability* --suppressions=${TokuDB_SOURCE_DIR}/src/tests/drd.suppressions --trace-children=yes --trace-children-skip=sh,*/sh,basename,*/basename,dirname,*/dirname,rm,*/rm,cp,*/cp,mv,*/mv,cat,*/cat,diff,*/diff,grep,*/grep,date,*/date,test,*/tokudb_dump* --trace-children-skip-by-arg=--only_create,--test,--no-shutdown,novalgrind --fair-sched=try")
   function(add_drd_test pfx name)
     separate_arguments(CMAKE_DRD_COMMAND_STRING)
     add_test(

--- a/cmake_modules/TokuSetupCTest.cmake
+++ b/cmake_modules/TokuSetupCTest.cmake
@@ -94,6 +94,8 @@ if (BUILD_TESTING OR BUILD_FT_TESTS OR BUILD_SRC_TESTS)
   ## set up full valgrind suppressions file (concatenate the suppressions files)
   file(READ ft/valgrind.suppressions valgrind_suppressions)
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/valgrind.suppressions" "${valgrind_suppressions}")
+  file(READ third_party/xz.suppressions xz_suppressions)
+  file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/valgrind.suppressions" "${xz_suppressions}")
   file(READ bash.suppressions bash_suppressions)
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/valgrind.suppressions" "${bash_suppressions}")
 

--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -108,6 +108,9 @@ set_cflags_if_supported(
   -fno-rtti
   -fno-exceptions
   -Wno-error=nonnull-compare
+  -Wno-error=parentheses
+  -Wno-error=address-of-packed-member
+  -Wno-deprecated-copy
   )
 ## set_cflags_if_supported_named("-Weffc++" -Weffcpp)
 

--- a/ft/ft-internal.h
+++ b/ft/ft-internal.h
@@ -80,7 +80,7 @@ extern "C" {
 extern uint force_recovery;
 }
 
-extern int writing_rollback;
+extern std::atomic_int writing_rollback;
 
 // The ft_header is not managed by the cachetable.  Instead, it hangs off the cachefile as userdata.
 struct ft_header {

--- a/ft/ft.cc
+++ b/ft/ft.cc
@@ -50,6 +50,8 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <toku_assert.h>
 #include <portability/toku_atomic.h>
 
+extern "C" { uint force_recovery = 0; }
+
 toku_instr_key *ft_ref_lock_mutex_key;
 
 void toku_reset_root_xid_that_created(FT ft, TXNID new_root_xid_that_created) {

--- a/ft/logger/logger.cc
+++ b/ft/logger/logger.cc
@@ -49,7 +49,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "util/status.h"
 
-int writing_rollback = 0;
+std::atomic_int writing_rollback { 0 };
 
 static const int log_format_version = TOKU_LOG_VERSION;
 

--- a/ft/node.h
+++ b/ft/node.h
@@ -155,7 +155,7 @@ private:
     size_t _total_size;
 };
 
-extern int writing_rollback;
+extern std::atomic_int writing_rollback;
 
 extern "C" {
 extern uint force_recovery;

--- a/ft/tests/CMakeLists.txt
+++ b/ft/tests/CMakeLists.txt
@@ -123,22 +123,4 @@ if(BUILD_TESTING OR BUILD_FT_TESTS)
     get_filename_component(test_basename "${test}" NAME)
     add_ft_test_aux(test-${test_basename} test-upgrade-recovery-logs ${test})
   endforeach(test)
-
-  ## give some tests, that time out normally, 1 hour to complete
-  set(long_tests
-    ft/ftloader-test-extractor-3a
-    ft/log-test7
-    ft/recovery-bad-last-entry
-    ft/subblock-test-compression
-    ft/upgrade_test_simple
-    )
-  set_tests_properties(${long_tests} PROPERTIES TIMEOUT 3600)
-  ## some take even longer, with valgrind
-  set(extra_long_tests
-    ft/benchmark-test
-    ft/benchmark-test_256
-    ft/is_empty
-    ft/subblock-test-checksum
-    )
-  set_tests_properties(${extra_long_tests} PROPERTIES TIMEOUT 7200)
 endif(BUILD_TESTING OR BUILD_FT_TESTS)

--- a/ft/tests/cachetable-simple-close.cc
+++ b/ft/tests/cachetable-simple-close.cc
@@ -38,6 +38,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 #include "test.h"
 #include "cachetable-test.h"
+#include <string>
 
 bool close_called;
 bool free_called;
@@ -193,15 +194,15 @@ static void test_multiple_cachefiles(bool use_same_hash) {
         CACHETABLE ct;
         toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
 
-        char fname1[strlen(TOKU_TEST_FILENAME) + sizeof("_1")];    
-        strcpy(fname1, TOKU_TEST_FILENAME);
-        strncat(fname1, "_1", sizeof("_1"));
-        char fname2[strlen(TOKU_TEST_FILENAME) + sizeof("_2")];    
-        strcpy(fname2, TOKU_TEST_FILENAME);
-        strncat(fname2, "_2", sizeof("_2"));
-        char fname3[strlen(TOKU_TEST_FILENAME) + sizeof("_3")];    
-        strcpy(fname3, TOKU_TEST_FILENAME);
-        strncat(fname3, "_3", sizeof("_3"));
+        std::string fname1s(TOKU_TEST_FILENAME);
+        fname1s.append("_1");
+        const char *fname1 = fname1s.c_str();
+        std::string fname2s(TOKU_TEST_FILENAME);
+        fname2s.append("_2");
+        const char *fname2 = fname2s.c_str();
+        std::string fname3s(TOKU_TEST_FILENAME);
+        fname3s.append("_3");
+        const char *fname3 = fname3s.c_str();
 
         unlink(fname1);
         unlink(fname2);
@@ -242,7 +243,7 @@ static void test_multiple_cachefiles(bool use_same_hash) {
         toku_cachefile_close(&f2, false, ZERO_LSN);
         toku_cachefile_close(&f3, false, ZERO_LSN);
 
-        char* fname_to_open = NULL;
+        const char* fname_to_open = NULL;
         if (iter == 0) {
             fname_to_open  = fname1;
         }
@@ -278,12 +279,12 @@ static void test_evictor(void) {
     CACHETABLE ct;
     toku_cachetable_create(&ct, test_limit, ZERO_LSN, nullptr);
 
-    char fname1[strlen(TOKU_TEST_FILENAME) + sizeof("_1")];    
-    strcpy(fname1, TOKU_TEST_FILENAME);
-    strncat(fname1, "_1", sizeof("_1"));
-    char fname2[strlen(TOKU_TEST_FILENAME) + sizeof("_2")];    
-    strcpy(fname2, TOKU_TEST_FILENAME);
-    strncat(fname2, "_2", sizeof("_2"));
+    std::string fname1s(TOKU_TEST_FILENAME);
+    fname1s.append("_1");
+    const char *fname1 = fname1s.c_str();
+    std::string fname2s(TOKU_TEST_FILENAME);
+    fname2s.append("_2");
+    const char *fname2 = fname2s.c_str();
 
     unlink(fname1);
     unlink(fname2);

--- a/ft/tests/ft-bfe-query.cc
+++ b/ft/tests/ft-bfe-query.cc
@@ -337,7 +337,7 @@ static void test_prefetching(void) {
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 1;
     sn.n_children = 3;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
 
     uint64_t key1 = 100;

--- a/ft/tests/ft-clock-test.cc
+++ b/ft/tests/ft-clock-test.cc
@@ -133,7 +133,7 @@ static void test1(int fd, FT ft_h, FTNODE *dn) {
     for (int i = 0; i < (*dn)->n_children; i++) {
         invariant(BP_STATE(*dn, i) == PT_AVAIL);
     }
-    (*dn)->dirty = 1;
+    (*dn)->set_dirty();
     toku_ftnode_pe_callback(*dn, attr, ft_h, def_pe_finalize_impl, nullptr);
     toku_ftnode_pe_callback(*dn, attr, ft_h, def_pe_finalize_impl, nullptr);
     toku_ftnode_pe_callback(*dn, attr, ft_h, def_pe_finalize_impl, nullptr);
@@ -246,7 +246,7 @@ static void test_serialize_nonleaf(void) {
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 1;
     sn.n_children = 2;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(2, sn.bp);
     DBT pivotkey;
@@ -384,7 +384,7 @@ static void test_serialize_leaf(void) {
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 2;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn.n_children, sn.bp);
     DBT pivotkey;

--- a/ft/tests/ft-serialize-benchmark.cc
+++ b/ft/tests/ft-serialize-benchmark.cc
@@ -95,7 +95,7 @@ static void test_serialize_leaf(int valsize,
     sn->layout_version_original = FT_LAYOUT_VERSION;
     sn->height = 0;
     sn->n_children = 8;
-    sn->dirty = 1;
+    sn->set_dirty();
     sn->oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn->n_children, sn->bp);
     sn->pivotkeys.create_empty();
@@ -173,7 +173,7 @@ static void test_serialize_leaf(int valsize,
     for (int i = 0; i < ser_runs; i++) {
         gettimeofday(&t[0], NULL);
         ndd = NULL;
-        sn->dirty = 1;
+        sn->set_dirty();
         r = toku_serialize_ftnode_to(
             fd, make_blocknum(20), sn, &ndd, true, ft->ft, false);
         invariant(r == 0);
@@ -265,7 +265,7 @@ static void test_serialize_nonleaf(int valsize,
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 1;
     sn.n_children = 8;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn.n_children, sn.bp);
     sn.pivotkeys.create_empty();

--- a/ft/tests/ft-serialize-test.cc
+++ b/ft/tests/ft-serialize-test.cc
@@ -238,7 +238,7 @@ static void test_serialize_leaf_check_msn(enum ftnode_verify_type bft,
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 2;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn.n_children, sn.bp);
     DBT pivotkey;
@@ -381,7 +381,7 @@ static void test_serialize_leaf_with_large_pivots(enum ftnode_verify_type bft,
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = nrows;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
 
     MALLOC_N(sn.n_children, sn.bp);
@@ -538,7 +538,7 @@ static void test_serialize_leaf_with_many_rows(enum ftnode_verify_type bft,
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 1;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
 
     XMALLOC_N(sn.n_children, sn.bp);
@@ -693,7 +693,7 @@ static void test_serialize_leaf_with_large_rows(enum ftnode_verify_type bft,
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 1;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
 
     MALLOC_N(sn.n_children, sn.bp);
@@ -845,7 +845,7 @@ static void test_serialize_leaf_with_empty_basement_nodes(
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 7;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn.n_children, sn.bp);
     DBT pivotkeys[6];
@@ -989,7 +989,7 @@ static void test_serialize_leaf_with_multiple_empty_basement_nodes(
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 0;
     sn.n_children = 4;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(sn.n_children, sn.bp);
     DBT pivotkeys[3];
@@ -1100,7 +1100,7 @@ static void test_serialize_nonleaf(enum ftnode_verify_type bft, bool do_clone) {
     sn.layout_version_original = FT_LAYOUT_VERSION;
     sn.height = 1;
     sn.n_children = 2;
-    sn.dirty = 1;
+    sn.set_dirty();
     sn.oldest_referenced_xid_known = TXNID_NONE;
     MALLOC_N(2, sn.bp);
     DBT pivotkey;

--- a/ft/tests/ft-test-header.cc
+++ b/ft/tests/ft-test-header.cc
@@ -57,7 +57,7 @@ static void test_header (void) {
     assert(r==0);
     // now insert some info into the header
     FT ft = t->ft;
-    ft->h->dirty = 1;
+    ft->h->set_dirty();
     // cast away const because we actually want to fiddle with the header
     // in this test
     *((int *) &ft->h->layout_version_original) = 13;

--- a/ft/tests/make-tree.cc
+++ b/ft/tests/make-tree.cc
@@ -88,7 +88,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
     leafnode->max_msn_applied_to_node_on_disk = msn;
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/tests/mempool-115.cc
+++ b/ft/tests/mempool-115.cc
@@ -102,7 +102,7 @@ public:
         sn.layout_version_original = FT_LAYOUT_VERSION;
         sn.height = 0;
         sn.n_children = 2;
-        sn.dirty = 1;
+        sn.set_dirty();
         sn.oldest_referenced_xid_known = TXNID_NONE;
         MALLOC_N(sn.n_children, sn.bp);
         DBT pivotkey;

--- a/ft/tests/msnfilter.cc
+++ b/ft/tests/msnfilter.cc
@@ -161,7 +161,7 @@ append_leaf(FT_HANDLE ft, FTNODE leafnode, void *key, uint32_t keylen, void *val
     }
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void 

--- a/ft/tests/test-checkpoint-during-flush.cc
+++ b/ft/tests/test-checkpoint-during-flush.cc
@@ -245,7 +245,7 @@ doit (bool after_child_pin) {
         true
         );
     assert(node->height == 1);
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 1);
     if (after_child_pin) {
         assert(toku_bnc_nbytesinbuf(BNC(node, 0)) == 0);
@@ -265,7 +265,7 @@ doit (bool after_child_pin) {
         true
         );
     assert(node->height == 0);
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 1);
     if (after_child_pin) {
         assert(BLB_NBYTESINDATA(node,0) > 0);

--- a/ft/tests/test-checkpoint-during-merge.cc
+++ b/ft/tests/test-checkpoint-during-merge.cc
@@ -270,7 +270,7 @@ doit (int state) {
         true
         );
     assert(node->height == 1);
-    assert(!node->dirty);
+    assert(!node->dirty());
     BLOCKNUM left_child, right_child;
     // cases where we expect the checkpoint to contain the merge
     if (state == ft_flush_aflter_merge || state == flt_flush_before_unpin_remove) {
@@ -301,7 +301,7 @@ doit (int state) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 1);
         toku_unpin_ftnode(c_ft->ft, node);
@@ -318,7 +318,7 @@ doit (int state) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 1);
         toku_unpin_ftnode(c_ft->ft, node);
@@ -336,7 +336,7 @@ doit (int state) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 2);
         toku_unpin_ftnode(c_ft->ft, node);

--- a/ft/tests/test-checkpoint-during-rebalance.cc
+++ b/ft/tests/test-checkpoint-during-rebalance.cc
@@ -284,7 +284,7 @@ doit (int state) {
         true
         );
     assert(node->height == 1);
-    assert(!node->dirty);
+    assert(!node->dirty());
     BLOCKNUM left_child, right_child;
 
     assert(node->n_children == 2);
@@ -304,7 +304,7 @@ doit (int state) {
         true
         );
     assert(node->height == 0);
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 1);
     assert(BLB_DATA(node, 0)->num_klpairs() == 2);
     toku_unpin_ftnode(c_ft->ft, node);
@@ -319,7 +319,7 @@ doit (int state) {
         true
         );
     assert(node->height == 0);
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 1);
     assert(BLB_DATA(node, 0)->num_klpairs() == 2);
     toku_unpin_ftnode(c_ft->ft, node);

--- a/ft/tests/test-checkpoint-during-split.cc
+++ b/ft/tests/test-checkpoint-during-split.cc
@@ -260,7 +260,7 @@ doit (bool after_split) {
         true
         );
     assert(node->height == 1);
-    assert(!node->dirty);
+    assert(!node->dirty());
     BLOCKNUM left_child, right_child;
     if (after_split) {
         assert(node->n_children == 2);
@@ -287,7 +287,7 @@ doit (bool after_split) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 1);
         toku_unpin_ftnode(c_ft->ft, node);
@@ -302,7 +302,7 @@ doit (bool after_split) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 1);
         toku_unpin_ftnode(c_ft->ft, node);
@@ -318,7 +318,7 @@ doit (bool after_split) {
             true
             );
         assert(node->height == 0);
-        assert(!node->dirty);
+        assert(!node->dirty());
         assert(node->n_children == 1);
         assert(BLB_DATA(node, 0)->num_klpairs() == 2);
         toku_unpin_ftnode(c_ft->ft, node);

--- a/ft/tests/test-dirty-flushes-on-cleaner.cc
+++ b/ft/tests/test-dirty-flushes-on-cleaner.cc
@@ -199,7 +199,7 @@ doit (void) {
         &node,
         true
         );
-    assert(node->dirty);
+    assert(node->dirty());
     assert(node->n_children == 2);
     assert(BP_STATE(node,0) == PT_AVAIL);
     assert(BP_STATE(node,1) == PT_AVAIL);
@@ -229,7 +229,7 @@ doit (void) {
         &node,
         true
         );
-    assert(node->dirty);
+    assert(node->dirty());
     assert(node->n_children == 2);
     assert(BP_STATE(node,0) == PT_AVAIL);
     assert(BP_STATE(node,1) == PT_AVAIL);
@@ -250,7 +250,7 @@ doit (void) {
         &node,
         true
         );
-    assert(node->dirty);
+    assert(node->dirty());
 
     // we expect that this flushes its buffer, that
     // a merge is not done, and that the lookup

--- a/ft/tests/test-flushes-on-cleaner.cc
+++ b/ft/tests/test-flushes-on-cleaner.cc
@@ -203,7 +203,7 @@ doit (bool keep_other_bn_in_memory) {
         &node,
         true
         );
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 2);
     // a hack to get the basement nodes evicted
     for (int i = 0; i < 20; i++) {
@@ -249,7 +249,7 @@ doit (bool keep_other_bn_in_memory) {
         &node,
         true
         );
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(node->n_children == 2);
     assert(BP_STATE(node,0) == PT_AVAIL);
     if (keep_other_bn_in_memory) {
@@ -273,7 +273,7 @@ doit (bool keep_other_bn_in_memory) {
         &node,
         true
         );
-    assert(!node->dirty);
+    assert(!node->dirty());
 
     // we expect that this flushes its buffer, that
     // a merge is not done, and that the lookup

--- a/ft/tests/test-pick-child-to-flush.cc
+++ b/ft/tests/test-pick-child-to-flush.cc
@@ -194,7 +194,7 @@ doit (void) {
     toku_pin_node_with_min_bfe(&node, node_internal, t);
     toku_ftnode_assert_fully_in_memory(node);
     assert(node->n_children == 2);
-    assert(!node->dirty);
+    assert(!node->dirty());
     assert(toku_bnc_n_entries(node->bp[0].ptr.u.nonleaf) > 0);
     assert(toku_bnc_n_entries(node->bp[1].ptr.u.nonleaf) > 0);
 
@@ -216,7 +216,7 @@ doit (void) {
 
     toku_pin_node_with_min_bfe(&node, node_internal, t);
     toku_ftnode_assert_fully_in_memory(node);
-    assert(node->dirty);
+    assert(node->dirty());
     assert(node->n_children == 2);
     // child 0 should have empty buffer because it flushed
     // child 1 should still have message in buffer
@@ -226,14 +226,14 @@ doit (void) {
     r = toku_checkpoint(cp, NULL, NULL, NULL, NULL, NULL, CLIENT_CHECKPOINT);
     assert_zero(r);    
     toku_pin_node_with_min_bfe(&node, node_internal, t);
-    assert(!node->dirty);
+    assert(!node->dirty());
     curr_child_to_flush = 1;
     num_flushes_called = 0;
     toku_ft_flush_some_child(t->ft, node, &fa);
     assert(num_flushes_called == 1);
     
     toku_pin_node_with_min_bfe(&node, node_internal, t);
-    assert(node->dirty);
+    assert(node->dirty());
     toku_ftnode_assert_fully_in_memory(node);
     assert(node->n_children == 2);
     // both buffers should be empty now
@@ -244,14 +244,14 @@ doit (void) {
     r = toku_checkpoint(cp, NULL, NULL, NULL, NULL, NULL, CLIENT_CHECKPOINT);
     assert_zero(r);    
     toku_pin_node_with_min_bfe(&node, node_internal, t);
-    assert(!node->dirty);
+    assert(!node->dirty());
     curr_child_to_flush = 0;
     num_flushes_called = 0;
     toku_ft_flush_some_child(t->ft, node, &fa);
     assert(num_flushes_called == 1);
 
     toku_pin_node_with_min_bfe(&node, node_internal, t);
-    assert(node->dirty); // nothing was flushed, but since we were trying to flush to a leaf, both become dirty
+    assert(node->dirty()); // nothing was flushed, but since we were trying to flush to a leaf, both become dirty
     toku_ftnode_assert_fully_in_memory(node);
     assert(node->n_children == 2);
     // both buffers should be empty now
@@ -280,17 +280,17 @@ doit (void) {
         assert(num_flushes_called == 2);
     
         toku_pin_node_with_min_bfe(&node, node_internal, t);
-        assert(node->dirty);
+        assert(node->dirty());
         toku_unpin_ftnode(t->ft, node);
         toku_pin_node_with_min_bfe(&node, node_leaf[0], t);
-        assert(node->dirty);
+        assert(node->dirty());
         toku_unpin_ftnode(t->ft, node);
         toku_pin_node_with_min_bfe(&node, node_leaf[1], t);
         if (i == 0) {
-            assert(!node->dirty);
+            assert(!node->dirty());
         }
         else {
-            assert(node->dirty);
+            assert(node->dirty());
         }
         toku_unpin_ftnode(t->ft, node);
     }

--- a/ft/tests/test3884.cc
+++ b/ft/tests/test3884.cc
@@ -105,7 +105,7 @@ setup_ftnode_header(struct ftnode *node)
     node->layout_version = FT_LAYOUT_VERSION;
     node->layout_version_original = FT_LAYOUT_VERSION;
     node->height = 0;
-    node->dirty = 1;
+    node->set_dirty();
     node->oldest_referenced_xid_known = TXNID_NONE;
 }
 

--- a/ft/tests/verify-bad-msn.cc
+++ b/ft/tests/verify-bad-msn.cc
@@ -93,7 +93,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
     // leafnode->max_msn_applied_to_node = msn;
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/tests/verify-bad-pivots.cc
+++ b/ft/tests/verify-bad-pivots.cc
@@ -77,7 +77,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/tests/verify-dup-in-leaf.cc
+++ b/ft/tests/verify-dup-in-leaf.cc
@@ -78,7 +78,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void 

--- a/ft/tests/verify-dup-pivots.cc
+++ b/ft/tests/verify-dup-pivots.cc
@@ -77,7 +77,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/tests/verify-misrouted-msgs.cc
+++ b/ft/tests/verify-misrouted-msgs.cc
@@ -78,7 +78,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/tests/verify-unsorted-leaf.cc
+++ b/ft/tests/verify-unsorted-leaf.cc
@@ -80,7 +80,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void 

--- a/ft/tests/verify-unsorted-pivots.cc
+++ b/ft/tests/verify-unsorted-pivots.cc
@@ -77,7 +77,7 @@ append_leaf(FTNODE leafnode, void *key, size_t keylen, void *val, size_t vallen)
         NULL);
 
     // don't forget to dirty the node
-    leafnode->dirty = 1;
+    leafnode->set_dirty();
 }
 
 static void

--- a/ft/txn/rollback.cc
+++ b/ft/txn/rollback.cc
@@ -43,7 +43,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include "ft/logger/log-internal.h"
 #include "ft/txn/rollback-ct-callbacks.h"
 
-extern int writing_rollback;
+extern std::atomic_int writing_rollback;
 
 static void rollback_unpin_remove_callback(CACHEKEY* cachekey, bool for_checkpoint, void* extra) {
     FT CAST_FROM_VOIDP(ft, extra);

--- a/locktree/tests/lock_request_start_retry_race.cc
+++ b/locktree/tests/lock_request_start_retry_race.cc
@@ -83,7 +83,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)

--- a/locktree/tests/lock_request_start_retry_race_3.cc
+++ b/locktree/tests/lock_request_start_retry_race_3.cc
@@ -96,7 +96,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)

--- a/locktree/tests/lock_request_start_retry_wait_race_2.cc
+++ b/locktree/tests/lock_request_start_retry_wait_race_2.cc
@@ -98,7 +98,6 @@ namespace toku {
             }
 
             request.destroy();
-            memset(&request, 0xab, sizeof request);
 
             toku_pthread_yield();
             if ((i % 10) == 0)

--- a/portability/tests/test-xid.cc
+++ b/portability/tests/test-xid.cc
@@ -54,7 +54,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 // since we implement the same thing here as in toku_os_gettid, this test
 // is pretty pointless
-static int gettid(void) {
+static int test_gettid(void) {
 #if defined(__NR_gettid)
     return syscall(__NR_gettid);
 #elif defined(SYS_gettid)
@@ -68,6 +68,6 @@ static int gettid(void) {
 
 int main(void) {
     assert(toku_os_getpid() == getpid());
-    assert(toku_os_gettid() == gettid());
+    assert(toku_os_gettid() == test_gettid());
     return 0;
 }

--- a/portability/toku_atomic.h
+++ b/portability/toku_atomic.h
@@ -58,6 +58,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdbool.h>
 #include <stdint.h>
 #include <stddef.h>
+#include <atomic>
 
 __attribute__((const, always_inline))
 static inline intptr_t which_cache_line(intptr_t addr) {

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -197,7 +197,6 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
       endif ()
 
       add_ydb_drd_test_aux(drd_tiny_${test} ${test} --num_seconds 5 --num_elements 150 --join_timeout 3000)
-      set_tests_properties(ydb/drd_tiny_${test} PROPERTIES TIMEOUT 3600)
 
       add_test(ydb/drd_mid_${test}/prepare ${test} --only_create --num_elements 10000)
       setup_toku_test_properties(ydb/drd_mid_${test}/prepare drd_mid_${test})
@@ -205,7 +204,6 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
       set_tests_properties(ydb/drd_mid_${test} PROPERTIES
         DEPENDS ydb/drd_mid_${test}/prepare
         REQUIRED_FILES "drd_mid_${test}.ctest-data"
-        TIMEOUT 15000
         )
 
       add_test(ydb/drd_large_${test}/prepare ${test} --only_create --num_elements 150000)
@@ -214,7 +212,6 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
       set_tests_properties(ydb/drd_large_${test} PROPERTIES
         DEPENDS ydb/drd_large_${test}/prepare
         REQUIRED_FILES "drd_large_${test}.ctest-data"
-        TIMEOUT 30000
         )
     endif()
   endforeach(src)
@@ -246,14 +243,12 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
               set_tests_properties(${testnamebase}/copy PROPERTIES
                 DEPENDS ${testnamebase}/remove
                 REQUIRED_FILES "${oldenvdir}")
-
               add_test(NAME ${testnamebase}
                 COMMAND ${test} --only_stress --num_elements ${size} --num_seconds 600 --join_timeout 7200)
               setup_toku_test_properties(${testnamebase} "${envdirbase}")
               set_tests_properties(${testnamebase} PROPERTIES
                 DEPENDS ${testnamebase}/copy
-                REQUIRED_FILES "${envdir}"
-                TIMEOUT 10800)
+                REQUIRED_FILES "${envdir}")
             endforeach(size)
           endif ()
         endforeach(p_or_s)
@@ -433,61 +428,4 @@ if(BUILD_TESTING OR BUILD_SRC_TESTS)
   string(REGEX REPLACE ";" ";ydb/" tdb_tests_that_should_fail "${tdb_tests_that_should_fail}")
   set_tests_properties(${tdb_tests_that_should_fail} PROPERTIES WILL_FAIL TRUE)
 
-  ## give some tests, that time out normally, 1 hour to complete
-  set(long_tests
-    ydb/drd_test_groupcommit_count.tdb
-    ydb/env-put-multiple.tdb
-    ydb/filesize.tdb
-    ydb/loader-cleanup-test0.tdb
-    ydb/loader-cleanup-test0z.tdb
-    ydb/manyfiles.tdb
-    ydb/recover-loader-test.abortrecover
-    ydb/recovery_fileops_stress.tdb
-    ydb/root_fifo_1.tdb
-    ydb/root_fifo_2.tdb
-    ydb/root_fifo_31.tdb
-    ydb/root_fifo_32.tdb
-    ydb/shutdown-3344.tdb
-    ydb/stat64-create-modify-times.tdb
-    ydb/test1572.tdb
-    ydb/test_abort4_19_0.tdb
-    ydb/test_abort4_19_1.tdb
-    ydb/test_abort5.tdb
-    ydb/test_archive1.tdb
-    ydb/test_logmax.tdb
-    ydb/test_query.tdb
-    ydb/test_txn_abort5.tdb
-    ydb/test_txn_abort5a.tdb
-    ydb/test_txn_abort6.tdb
-    ydb/test_txn_nested2.tdb
-    ydb/test_txn_nested4.tdb
-    ydb/test_txn_nested5.tdb
-    ydb/test_update_broadcast_stress.tdb
-    )
-  set_tests_properties(${long_tests} PROPERTIES TIMEOUT 3600)
-  ## some take even longer, with valgrind
-  set(extra_long_tests
-    ydb/drd_test_4015.tdb
-    ydb/hotindexer-with-queries.tdb
-    ydb/hot-optimize-table-tests.tdb
-    ydb/loader-cleanup-test2.tdb
-    ydb/loader-cleanup-test2z.tdb
-    ydb/loader-dup-test0.tdb
-    ydb/loader-stress-del.nop.loader
-    ydb/loader-stress-del.p.loader
-    ydb/loader-stress-del.comp.loader
-    ydb/test3039.tdb
-    ydb/test_update_stress.tdb
-    )
-  set_tests_properties(${extra_long_tests} PROPERTIES TIMEOUT 7200)
-  ## these really take a long time with valgrind
-  set(phenomenally_long_tests
-    ydb/checkpoint_stress.tdb
-    ydb/loader-stress-test4.tdb
-    ydb/loader-stress-test4z.tdb
-    ydb/recover_stress.tdb
-    ydb/test3529.tdb
-    ydb/test_insert_unique.tdb
-    )
-  set_tests_properties(${phenomenally_long_tests} PROPERTIES TIMEOUT 14400)
 endif(BUILD_TESTING OR BUILD_SRC_TESTS)

--- a/src/tests/helgrind.suppressions
+++ b/src/tests/helgrind.suppressions
@@ -156,3 +156,10 @@
     ...
     fun:pthread_mutex_destroy
 }
+{
+    pthread_mutex_destroy/pthread_mutex_unlock race glibc 2.30 gcc-9.2.1 valgrind-3.15.0
+    Helgrind:Race
+    obj:/usr/lib*/valgrind/vgpreload_helgrind-amd64-linux.so*
+    obj:/usr/lib*/valgrind/vgpreload_helgrind-amd64-linux.so*
+    fun:*toku_mutex_destroy*
+}

--- a/src/tests/recover-del-multiple-abort.cc
+++ b/src/tests/recover-del-multiple-abort.cc
@@ -57,9 +57,12 @@ get_data(int *v, int i, int ndbs) {
 static int
 put_callback(DB *dest_db, DB *src_db, DBT_ARRAY *dest_keys, DBT_ARRAY *dest_vals, const DBT *src_key, const DBT *src_val) {
     toku_dbt_array_resize(dest_keys, 1);
-    toku_dbt_array_resize(dest_vals, 1);
     DBT *dest_key = &dest_keys->dbts[0];
-    DBT *dest_val = &dest_vals->dbts[0];
+    DBT *dest_val = NULL;
+    if (dest_vals) {
+        toku_dbt_array_resize(dest_vals, 1);
+        dest_val = &dest_vals->dbts[0];
+    }
     (void) dest_db; (void) src_db; (void) dest_key; (void) dest_val; (void) src_key; (void) src_val;
     assert(src_db == NULL);
 

--- a/src/tests/test_memcmp_magic.cc
+++ b/src/tests/test_memcmp_magic.cc
@@ -103,7 +103,7 @@ static void test_memcmp_magic_sort_order(void) {
     DB_ENV *env;
     r = db_env_create(&env, 0); CKERR(r);
     r = env->set_default_bt_compare(env, comparison_function_unused); CKERR(r);
-    r = env->open(env, TOKU_TEST_FILENAME, DB_CREATE+DB_PRIVATE+DB_INIT_MPOOL+DB_INIT_TXN, 0); CKERR(r);
+    r = env->open(env, TOKU_TEST_FILENAME, DB_CREATE+DB_PRIVATE+DB_INIT_MPOOL+DB_INIT_TXN, S_IRUSR+S_IWUSR); CKERR(r);
 
     const int magic = 49;
 

--- a/src/tests/xa-bigtxn-discard-abort.cc
+++ b/src/tests/xa-bigtxn-discard-abort.cc
@@ -62,7 +62,7 @@ static void populate_foo(DB_ENV *env, DB_TXN *txn) {
     DB *db = nullptr;
     r = db_create(&db, env, 0);
     CKERR(r);
-    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, 0);
+    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, S_IRWXU);
     CKERR(r);
 
     for (int i = 0; i < test_nrows; i++) {
@@ -81,7 +81,7 @@ static void check_foo(DB_ENV *env, DB_TXN *txn) {
     DB *db;
     r = db_create(&db, env, 0);
     CKERR(r);
-    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, 0);
+    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, S_IRWXU);
     CKERR(r);
 
     DBC *c = nullptr;

--- a/src/tests/xa-bigtxn-discard-commit.cc
+++ b/src/tests/xa-bigtxn-discard-commit.cc
@@ -59,7 +59,7 @@ static void populate_foo(DB_ENV *env, DB_TXN *txn) {
     DB *db = nullptr;
     r = db_create(&db, env, 0);
     CKERR(r);
-    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, 0);
+    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, S_IRWXU);
     CKERR(r);
 
     for (int i = 0; i < test_nrows; i++) {
@@ -78,7 +78,7 @@ static void check_foo(DB_ENV *env, DB_TXN *txn) {
     DB *db;
     r = db_create(&db, env, 0);
     CKERR(r);
-    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, 0);
+    r = db->open(db, txn, "foo.db", 0, DB_BTREE, 0, S_IRWXU);
     CKERR(r);
 
     DBC *c = nullptr;

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -39,9 +39,6 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 extern const char *toku_patent_string;
 const char *toku_copyright_string = "Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.";
 
-
-extern int writing_rollback;
-
 #include <db.h>
 #include <errno.h>
 #include <string.h>
@@ -89,6 +86,8 @@ extern int writing_rollback;
  int toku_set_trace_file (const char *fname __attribute__((__unused__))) { return 0; }
  int toku_close_trace_file (void) { return 0; } 
 #endif
+
+extern std::atomic_int writing_rollback;
 
 extern "C" {
   extern uint force_recovery;

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -180,23 +180,27 @@ static int toku_maybe_get_engine_status_text (char* buff, int buffsize);  // for
 static int toku_maybe_err_engine_status (void);
 static void toku_maybe_set_env_panic(int code, const char * msg);               // for use by toku_assert
 
-int 
-toku_ydb_init(void) {
+static bool ydb_initialized = false;
+
+int toku_ydb_init(void) {
     int r = 0;
-    //Lower level must be initialized first.
-    r = toku_ft_layer_init();
+    if (!ydb_initialized) {
+        //Lower level must be initialized first.
+        r = toku_ft_layer_init();
+        if (r == 0)
+            ydb_initialized = true;
+    }
     return r;
 }
 
 // Do not clean up resources if env is panicked, just exit ugly
-void 
-toku_ydb_destroy(void) {
-    if (!ydb_layer_status.initialized)
+void toku_ydb_destroy(void) {
+    if (!ydb_initialized)
         return;
     if (env_is_panicked == 0) {
         toku_ft_layer_destroy();
     }
-    ydb_layer_status.initialized = false;
+    ydb_initialized = false;
 }
 
 static int

--- a/src/ydb.cc
+++ b/src/ydb.cc
@@ -91,7 +91,7 @@ extern int writing_rollback;
 #endif
 
 extern "C" {
-  uint force_recovery = 0;
+  extern uint force_recovery;
 }
 
 // Set when env is panicked, never cleared.

--- a/third_party/xz.suppressions
+++ b/third_party/xz.suppressions
@@ -1,0 +1,5 @@
+{
+    lzma: Conditional jump or move depends on uninitialised value (https://prohaska7.blogspot.com/2015/11/uninitialized-data-problem-in-lzma.html)
+    Memcheck:Cond
+    fun:lz_encoder_prepare
+}

--- a/util/tests/CMakeLists.txt
+++ b/util/tests/CMakeLists.txt
@@ -16,9 +16,4 @@ if(BUILD_TESTING)
   foreach(test ${tests})
     add_test(util/${test} ${test})
   endforeach(test)
-
-  set(long_tests
-    util/helgrind_test_partitioned_counter
-    )
-  set_tests_properties(${long_tests} PROPERTIES TIMEOUT 3600)
 endif(BUILD_TESTING)


### PR DESCRIPTION
Valgrind finds memory leaks of pfs keys for some ydb tests.  These tests create an environment, manipulate it, and close it.  These tests do not open the environment.  The bug is that the flag that controls the toku_ydb_destroy function is only set true if the environment is opened.  The flag should be set in the toku_ydb_init function.

Reproduce:
ctest -R ydb/test_cachesize -D ExperimentalMemCheck

Tools:
Ubuntu 19.10, Clang 7,8,9, Gcc 7,8,9, Cmake 3.14

Copyright (c) 2020, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.