### PR TITLE
Build perconaft with gcc-10 on ubuntu 20.04.

### DIFF
--- a/cmake_modules/TokuSetupCompiler.cmake
+++ b/cmake_modules/TokuSetupCompiler.cmake
@@ -2,6 +2,10 @@ function(add_c_defines)
   set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS ${ARGN})
 endfunction(add_c_defines)
 
+## always want these
+set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS "-Wall -Werror ${CMAKE_CXX_FLAGS}")
+
 if (APPLE)
   add_c_defines(DARWIN=1 _DARWIN_C_SOURCE)
 endif ()
@@ -169,10 +173,6 @@ if (NOT CMAKE_CXX_COMPILER_ID STREQUAL Clang)
   # Disabling -Wcast-align with clang.  TODO: fix casting and re-enable it, someday.
   prepend_cflags_if_supported(-Wcast-align)
 endif ()
-
-## always want these
-set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS "-Wall -Werror ${CMAKE_CXX_FLAGS}")
 
 # pick language dialect
 set(CMAKE_C_FLAGS "-std=c99 ${CMAKE_C_FLAGS}")

--- a/portability/tests/test-xid.cc
+++ b/portability/tests/test-xid.cc
@@ -54,7 +54,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 
 // since we implement the same thing here as in toku_os_gettid, this test
 // is pretty pointless
-static int gettid(void) {
+static int test_gettid(void) {
 #if defined(__NR_gettid)
     return syscall(__NR_gettid);
 #elif defined(SYS_gettid)
@@ -68,6 +68,6 @@ static int gettid(void) {
 
 int main(void) {
     assert(toku_os_getpid() == getpid());
-    assert(toku_os_gettid() == gettid());
+    assert(toku_os_gettid() == test_gettid());
     return 0;
 }


### PR DESCRIPTION
Build perconaft with gcc-10 on ubuntu 20.04.

Tools:
Ubuntu 20.04, Gcc 10.0.1, Cmake 3.16.3, libc-2.31

Copyright (c) 2020, Rik Prohaska
All rights reserved.

Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.