### PR TITLE
PS-7332: Skip mallopt in case code is built with ASAN support

### DIFF
--- a/portability/memory.cc
+++ b/portability/memory.cc
@@ -90,7 +90,9 @@ toku_memory_startup(void) {
 
     int result = 0;
 
-#if defined(HAVE_M_MMAP_THRESHOLD)
+    // The ASAN doesn't support mallopt, it simply returns 0 or -1
+    // depending on GCC version.
+#if defined(HAVE_M_MMAP_THRESHOLD) && !defined(__SANITIZE_ADDRESS__)
     // initialize libc malloc
     size_t mmap_threshold = 64 * 1024; // 64K and larger should be malloced with mmap().
     int success = mallopt(M_MMAP_THRESHOLD, mmap_threshold);


### PR DESCRIPTION
The ASAN doesn't support mallopt, it simply returns 0 or -1
depending on GCC version. With GCC 10 it returns 0 and this leads
to assertion failure.