### PR TITLE
Fix compilation against musl lib C

### DIFF
--- a/portability/toku_pthread.h
+++ b/portability/toku_pthread.h
@@ -156,7 +156,12 @@ typedef struct toku_mutex_aligned {
     { .pmutex = PTHREAD_MUTEX_INITIALIZER, .psi_mutex = nullptr }
 #endif  // defined(TOKU_PTHREAD_DEBUG)
 #else  // __FreeBSD__, __linux__, at least
+#if defined(__GLIBC__)
 #define TOKU_MUTEX_ADAPTIVE PTHREAD_MUTEX_ADAPTIVE_NP
+#else
+// not all libc (e.g. musl) implement NP (Non-POSIX) attributes
+#define TOKU_MUTEX_ADAPTIVE PTHREAD_MUTEX_DEFAULT
+#endif
 #if defined(TOKU_PTHREAD_DEBUG)
 #define TOKU_ADAPTIVE_MUTEX_INITIALIZER                                        \
     {                                                                          \


### PR DESCRIPTION
As I understand it `PTHREAD_MUTEX_ADAPTIVE_NP` is not supported on musl. The `_NP` part indicates a Non-POSIX extension implemented by GNU libc.

This small change fixes compilation on musl systems such as Alpine Linux.