### PR TITLE
PS-7621 - Improve detection of -DENABLED_DEBUG_SYNC in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,8 +27,10 @@ if (DEFINED MYSQL_PROJECT_NAME_DOCSTRING)
     add_definitions(-DTOKU_MYSQL_WITH_PFS)
   endif ()
   include_directories(${CMAKE_SOURCE_DIR}/include)
+  # Match exactly the flag `-DENABLED_DEBUG_SYNC` to prevent matching
+  # `-DENABLED_DEBUG_SYNC_EXTRA` or `EXTRA-DENABLED_DEBUG_SYNC`
   if ((CMAKE_BUILD_TYPE MATCHES "Debug") AND
-      (CMAKE_CXX_FLAGS_DEBUG MATCHES " -DENABLED_DEBUG_SYNC"))
+      (CMAKE_CXX_FLAGS_DEBUG MATCHES "( |^)-DENABLED_DEBUG_SYNC( |$)"))
     include_directories(${CMAKE_SOURCE_DIR}/sql)
   endif ()
 endif ()


### PR DESCRIPTION
MySql changed the way of adding the flag `-DENABLED_DEBUG_SYNC`,
which caused the variable not being recognized in CMakeLists.

https://github.com/mysql/mysql-server/blob/a9b0c712de3509d8d08d3ba385d41a4df6348775/CMakeLists.txt#L475

The proposed change is back compatible with the previous code.