### PR TITLE
PS-7622: Suppress implicit-fallthrough and unused-but-set-variable warn from liblzma

### DIFF
--- a/cmake_modules/TokuThirdParty.cmake
+++ b/cmake_modules/TokuThirdParty.cmake
@@ -7,7 +7,10 @@ if (APPLE)
   list(APPEND xz_configure_opts --disable-assembler)
 endif ()
 
-list(APPEND xz_configure_opts "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}")
+list(APPEND xz_configure_opts
+  "CC=${CMAKE_C_COMPILER} ${CMAKE_C_COMPILER_ARG1}"
+  "CFLAGS=-Wno-implicit-fallthrough -Wno-unused-but-set-variable")
+
 if (CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL drd)
   list(APPEND xz_configure_opts --enable-debug)
 endif ()


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7622