### PR TITLE
PS-7704: Travis CI: fix installation of clang-9 on Ubuntu Bionic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -164,8 +164,13 @@ script:
        TIMEOUT_CMD=timeout;
        CC=$CC-$VERSION;
        CXX=$CXX-$VERSION;
+       if [[ "$CC" == "clang-$VERSION" ]]; then
+         PACKAGES="$CC $PACKAGES";
+       else
+         PACKAGES="$CXX $PACKAGES";
+       fi;
        sudo -E apt-get -yq update >> ~/apt-get-update.log 2>&1;
-       sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install $CXX $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libevent-dev || travis_terminate 1;
+       sudo -E apt-get -yq --allow-unauthenticated --no-install-suggests --no-install-recommends install $PACKAGES cmake cmake-curses-gui bison libncurses5-dev libaio-dev libevent-dev || travis_terminate 1;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CC;
        sudo ln -s $(which ccache) /usr/lib/ccache/$CXX || echo;
     else


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7704

Do not try to install `clang++` which matches a regex.
This is a copy of similar fix for PS from
https://github.com/percona/percona-server/commit/952e65845d1813b221ca9713a2c0b2ba805b67e7.