### PR TITLE
PS-7622: Fix cmake warn while setting CMAKE_TOKUDB_REVISION variable

### DIFF
--- a/cmake_modules/TokuFeatureDetection.cmake
+++ b/cmake_modules/TokuFeatureDetection.cmake
@@ -132,4 +132,4 @@ static __thread int tlsvar = 0;
 int main(void) { return tlsvar; }" HAVE_GNU_TLS)
 
 ## set TOKUDB_REVISION
-set(CMAKE_TOKUDB_REVISION 0 CACHE INTEGER "Revision of tokudb.")
+set(CMAKE_TOKUDB_REVISION 0 CACHE STRING "Revision of tokudb.")


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7622

Fix "implicitly converting 'INTEGER' to 'STRING' type" warn while
setting CMAKE_TOKUDB_REVISION.