### PR TITLE
PS-7947: Fix assertion in toku_memory_startup() with Clang ASAN

### DIFF
--- a/portability/memory.cc
+++ b/portability/memory.cc
@@ -92,7 +92,7 @@ toku_memory_startup(void) {
 
     // The ASAN doesn't support mallopt, it simply returns 0 or -1
     // depending on GCC version.
-#if defined(HAVE_M_MMAP_THRESHOLD) && !defined(__SANITIZE_ADDRESS__)
+#if defined(HAVE_M_MMAP_THRESHOLD) && !defined(UNDER_ASAN)
     // initialize libc malloc
     size_t mmap_threshold = 64 * 1024; // 64K and larger should be malloced with mmap().
     int success = mallopt(M_MMAP_THRESHOLD, mmap_threshold);

--- a/portability/memory.h
+++ b/portability/memory.h
@@ -55,6 +55,18 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #include <stdlib.h>
 #include <toku_portability.h>
 
+#if defined(__clang__)
+#if defined(__has_feature)
+#if __has_feature(address_sanitizer)
+#define UNDER_ASAN 1
+#endif  // __has_feature(address_sanitizer)
+#endif  // defined(__has_feature)
+#else   // __clang__
+#ifdef __SANITIZE_ADDRESS__
+#define UNDER_ASAN 1
+#endif  // __SANITIZE_ADDRESS__
+#endif  // __clang__
+
 /* Percona memory allocation functions and macros.
  * These are functions for malloc and free */
 


### PR DESCRIPTION
https://jira.percona.com/browse/PS-7947

The ASAN doesn't support mallopt. Avoid using it in case of build
with Clang ASAN.