### PR TITLE
PS-8014 fix: Cannot find pthread_yield or pthread_yield_np when compiling PerconaFT on Impish

### DIFF
--- a/cmake_modules/TokuFeatureDetection.cmake
+++ b/cmake_modules/TokuFeatureDetection.cmake
@@ -109,6 +109,8 @@ check_function_exists(pthread_rwlockattr_setkind_np HAVE_PTHREAD_RWLOCKATTR_SETK
 ## check for the right way to yield using pthreads
 check_function_exists(pthread_yield HAVE_PTHREAD_YIELD)
 check_function_exists(pthread_yield_np HAVE_PTHREAD_YIELD_NP)
+check_function_exists(sched_yield HAVE_SCHED_YIELD)
+
 ## check if we have pthread_getthreadid_np() (i.e. freebsd)
 check_function_exists(pthread_getthreadid_np HAVE_PTHREAD_GETTHREADID_NP)
 check_function_exists(sched_getcpu HAVE_SCHED_GETCPU)

--- a/portability/toku_config.h.in
+++ b/portability/toku_config.h.in
@@ -87,6 +87,7 @@ Copyright (c) 2006, 2015, Percona and/or its affiliates. All rights reserved.
 #cmakedefine HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP 1
 #cmakedefine HAVE_PTHREAD_YIELD 1
 #cmakedefine HAVE_PTHREAD_YIELD_NP 1
+#cmakedefine HAVE_SCHED_YIELD 1
 #cmakedefine HAVE_PTHREAD_GETTHREADID_NP 1
 
 #cmakedefine PTHREAD_YIELD_RETURNS_INT 1

--- a/portability/toku_pthread.cc
+++ b/portability/toku_pthread.cc
@@ -67,7 +67,9 @@ int toku_pthread_yield(void) {
 #elif defined(HAVE_PTHREAD_YIELD_NP)
     pthread_yield_np();
     return 0;
+#elif defined(HAVE_SCHED_YIELD)
+    return sched_yield();
 #else
-# error "cannot find pthread_yield or pthread_yield_np"
+# error "cannot find pthread_yield or pthread_yield_np or sched_yield"
 #endif
 }


### PR DESCRIPTION
https://jira.percona.com/browse/PS-8014

On Ubuntu 21.10 Impish both 'pthread_yield()' and 'pthread_yield_np()'
functions are considered deprecated and trigger warnings when they
are used. This does not allow 'check_function_exists()' CMake macro
detect if these functions are present in the system.

To fix this, we now also check for the 'sched_yield()' function
and fall back to it if the previous two are not found or considered
deprecated.