### PR TITLE
Changed cmake_minimum_required VERSION to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (CMAKE_PROJECT_NAME STREQUAL TokuDB)
-  cmake_minimum_required(VERSION 2.8.8 FATAL_ERROR)
+  cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 endif()
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules")
 


### PR DESCRIPTION
Newer CMake binaries started to generate a warning if 'cmake_minimum_required' 'VERSION' is less than '2.8.12'.
Increased this 'VERSION' to suppress the warning.