### PR TITLE
toku_time.h: add macOS PPC support

### DIFF
--- a/portability/toku_time.h
+++ b/portability/toku_time.h
@@ -125,6 +125,16 @@ static inline tokutime_t toku_time_now(void) {
     return result;
 #elif defined(__powerpc__)
     return __ppc_get_timebase();
+#elif defined(__POWERPC__)
+    uint32_t upper, lower, tmp;
+    #define mftbu(r) __asm__ volatile("mftbu %0" : "=r"(r))
+    #define mftb(r)  __asm__ volatile("mftb  %0" : "=r"(r))
+    do {
+        mftbu(upper);
+        mftb(lower);
+        mftbu(tmp);
+    } while (tmp != upper);
+    return ((uint64_t)upper << 32) | lower;
 #else
 #error No timer implementation for this platform
 #endif


### PR DESCRIPTION
Add implementation for Darwin PPC. Based on: https://github.com/ruby/ruby/pull/5975#discussion_r890045558 

P. S. An alternative, older implementation: https://www.mcs.anl.gov/~kazutomo/rdtsc.html