### PR TITLE
Clarify licensing schema after d5178f513c0b4144a5ac9358ec0f6a3b54a28e76

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ All source code and test contributions must be provided under a [BSD 2-Clause][b
 License
 -------
 
-Portions of the PerconaFT library (the 'locktree' and 'omt') are available under the Apache version 2 license.
+Portions of the PerconaFT library (the 'locktree' and 'omt') along with their dependencies (`ft`, `portability`, `util` subdirectories) are available under the Apache version 2 license.
 PerconaFT is available under the GPL version 2, and AGPL version 3.
 See [COPYING.APACHEv2][apachelicense],
 [COPYING.AGPLv3][agpllicense],


### PR DESCRIPTION
The code under locktree depends on the code in util/, ft/ and portability/ subdirecties, yet the original commit did not clarified the license status in README.md.