### PR TITLE
fix: add default argument in constructor of toku_instr_key in toku_instrumentation

### DIFF
--- a/portability/toku_instrumentation.h
+++ b/portability/toku_instrumentation.h
@@ -95,7 +95,8 @@ class toku_instr_key {
    public:
     toku_instr_key(UU(toku_instr_object_type type),
                    UU(const char *group),
-                   UU(const char *name)) {}
+                   UU(const char *name),
+                   UU(const char *os_name) = NULL) {}
 
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
 


### PR DESCRIPTION
The code cannot be compile due to the error below.

/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc: In function ‘void toku_pfs_keys_init(const char*)’:
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4769:43: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [17], const char [13])’
         "extractor_thread", "tk_extractor");
                                           ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4772:39: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [15], const char [11])’
         "fractal_thread", "tk_fractal");
                                       ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4775:29: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [10], const char [6])’
         "io_thread", "tk_io");
                             ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4778:41: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [16], const char [12])’
         "eviction_thread", "tk_eviction");
                                         ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4781:39: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [15], const char [11])’
         "kibbutz_thread", "tk_kibbutz");
                                       ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4784:41: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [16], const char [12])’
         "minicron_thread", "tk_minicron");
                                         ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:4787:45: error: no matching function for call to ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*&, const char [19], const char [13])’
         "tp_internal_thread", "tk_tp_intrnl");
                                             ^
In file included from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_portability.h:167,
                 from /home/yizhengjiao/design_pattern/PerconaFT/portability/toku_pthread.h:59,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/serialize/block_table.h:44,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/logger/logger.h:41,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/cachetable.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/cachetable/checkpoint.h:43,
                 from /home/yizhengjiao/design_pattern/PerconaFT/ft/ft-ops.cc:150:
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note: candidate: ‘toku_instr_key::toku_instr_key(pfs_key_t)’
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
              ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:100:14: note:   candidate expects 1 argument, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note: candidate: ‘toku_instr_key::toku_instr_key(toku_instr_object_type, const char*, const char*)’
     toku_instr_key(UU(toku_instr_object_type type),
     ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:96:5: note:   candidate expects 3 arguments, 4 provided
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note: candidate: ‘constexpr toku_instr_key::toku_instr_key(const toku_instr_key&)’
 class toku_instr_key {
       ^~~~~~~~~~~~~~
/home/yizhengjiao/design_pattern/PerconaFT/portability/toku_instrumentation.h:94:7: note:   candidate expects 1 argument, 4 provided
make[2]: *** [ft/CMakeFiles/ft.dir/build.make:212: ft/CMakeFiles/ft.dir/ft-ops.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:676: ft/CMakeFiles/ft.dir/all] Error 2
make: *** [Makefile:136: all] Error 2