### PR TITLE
fix compile error due to parameter of toku_instr_key's constructor

### DIFF
--- a/portability/toku_instrumentation.h
+++ b/portability/toku_instrumentation.h
@@ -95,7 +95,8 @@ class toku_instr_key {
    public:
     toku_instr_key(UU(toku_instr_object_type type),
                    UU(const char *group),
-                   UU(const char *name)) {}
+                   UU(const char *name),
+		   UU(const char *os_name) = NULL) {}
 
     explicit toku_instr_key(UU(pfs_key_t key_id)) {}
 


### PR DESCRIPTION
This compilation error only occurs in non MySQL/Percona contexts.